### PR TITLE
core: init pending state in tx pool on creation

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -100,6 +100,8 @@ func NewTxPool(config *ChainConfig, eventMux *event.TypeMux, currentStateFn stat
 		quit:         make(chan struct{}),
 	}
 
+	pool.resetState()
+
 	pool.wg.Add(2)
 	go pool.eventLoop()
 	go pool.expirationLoop()
@@ -348,10 +350,6 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) {
 //
 // Note, this method assumes the pool lock is held!
 func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) {
-	// Init delayed since tx pool could have been started before any state sync
-	if pool.pendingState == nil {
-		pool.resetState()
-	}
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
 		pool.pending[addr] = newTxList(true)


### PR DESCRIPTION
The transaction pool keeps an internal pending state to track the current nonce for an account. If a user submits a transaction before this pending state was initialized the node crashes. This PR will initialize the pending state when the transaction pool is created and therefore guarantees the state is always ready for use.

Fixes #24 