### PR TITLE
state: take write lock in GetNonce

### DIFF
--- a/core/state/managed_state.go
+++ b/core/state/managed_state.go
@@ -82,10 +82,12 @@ func (ms *ManagedState) NewNonce(addr common.Address) uint64 {
 	return uint64(len(account.nonces)-1) + account.nstart
 }
 
-// GetNonce returns the canonical nonce for the managed or unmanaged account
+// GetNonce returns the canonical nonce for the managed or unmanaged account.
+//
+// Because GetNonce mutates the DB, we must take a write lock.
 func (ms *ManagedState) GetNonce(addr common.Address) uint64 {
-	ms.mu.RLock()
-	defer ms.mu.RUnlock()
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
 
 	if ms.hasAccount(addr) {
 		account := ms.getAccount(addr)


### PR DESCRIPTION
This patch was recently accepted upstream: ethereum/go-ethereum#3625.

------

We must take a write (vs read) lock here because `GetNonce` calls`StateDB.GetStateObject`, which mutates the DB's live set.

During a long-running stress test, I ran into a panic that was caused by this problem:

```
fatal error: concurrent map writes

goroutine 80 [running]:
runtime.throw(0x12a1a90, 0x15)
    /usr/lib/go-1.6/src/runtime/panic.go:547 +0x90 fp=0xc8202b6698 sp=0xc8202b6680
runtime.mapassign1(0xe32fe0, 0xc831c99d70, 0xc8202b67a0, 0xc8202b67e8)
    /usr/lib/go-1.6/src/runtime/hashmap.go:445 +0xb1 fp=0xc8202b6740 sp=0xc8202b6698
github.com/ethereum/go-ethereum/core/state.(*StateDB).GetStateObject(0xc8329eb4a0, 0xd6907f33b5e26a5e, 0xb4f64f7a18c76f8a, 0xc89f0c6e83, 0xc8202b69d8)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/state/statedb.go:400 +0x6f8 fp=0xc8202b6998 sp=0xc8202b6740
github.com/ethereum/go-ethereum/core/state.(*StateDB).GetNonce(0xc8329eb4a0, 0xd6907f33b5e26a5e, 0xb4f64f7a18c76f8a, 0x9f0c6e83, 0x568f00)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/state/statedb.go:230 +0x33 fp=0xc8202b69c8 sp=0xc8202b6998
github.com/ethereum/go-ethereum/core/state.(*ManagedState).GetNonce(0xc831c99e90, 0xd6907f33b5e26a5e, 0xb4f64f7a18c76f8a, 0x9f0c6e83, 0x0)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/state/managed_state.go:94 +0x12f fp=0xc8202b6a20 sp=0xc8202b69c8
github.com/ethereum/go-ethereum/core.(*TxPool).promoteExecutables(0xc82023e140)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/tx_pool.go:510 +0x651 fp=0xc8202b6f50 sp=0xc8202b6a20
github.com/ethereum/go-ethereum/core.(*TxPool).AddBatch(0xc82023e140, 0xc83a7e5240, 0x1, 0x4)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/core/tx_pool.go:406 +0x28d fp=0xc8202b7020 sp=0xc8202b6f50
github.com/ethereum/go-ethereum/eth.(*ProtocolManager).handleMsg(0xc8201c4b60, 0xc8201a0000, 0x0, 0x0)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/handler.go:688 +0x616b fp=0xc8202b7b38 sp=0xc8202b7020
github.com/ethereum/go-ethereum/eth.(*ProtocolManager).handle(0xc8201c4b60, 0xc8201a0000, 0x0, 0x0)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/handler.go:301 +0xb36 fp=0xc8202b7d28 sp=0xc8202b7b38
github.com/ethereum/go-ethereum/eth.NewProtocolManager.func1(0xc82007c480, 0x7fad4946ece0, 0xc820262070, 0x0, 0x0)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/eth/handler.go:130 +0x17c fp=0xc8202b7e38 sp=0xc8202b7d28
github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1(0xc820262070, 0xc82007c480)
    /root/go/src/github.com/ethereum/go-ethereum/build/_workspace/src/github.com/ethereum/go-ethereum/p2p/peer.go:303 +0x8d fp=0xc8202b7f80 sp=0xc8202b7e38
```