### PR TITLE
Check that msg.To() is not nil in GetVMEnv

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -102,7 +102,7 @@ func (b *EthApiBackend) GetVMEnv(ctx context.Context, msg core.Message, state et
 		privateState = statedb.privateState
 	)
 
-	if !privateState.Exist(*msg.To()) {
+	if msg.To() != nil && !privateState.Exist(*msg.To()) {
 		privateState = publicState
 	}
 


### PR DESCRIPTION
Otherwise it will panic when msg is creating a contract.

Closes: #50