### PR TITLE
Dynamic raft membership support

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -158,7 +158,7 @@ participating.
 		utils.SingleBlockMakerFlag,
 		utils.EnableNodePermissionFlag,
 		utils.RaftModeFlag,
-		utils.RaftBlockTime,
+		utils.RaftBlockTimeFlag,
 		utils.RaftJoinExistingFlag,
 	}
 	app.Flags = append(app.Flags, debug.Flags...)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -159,6 +159,7 @@ participating.
 		utils.EnableNodePermissionFlag,
 		utils.RaftModeFlag,
 		utils.RaftBlockTime,
+		utils.RaftJoinExistingFlag,
 	}
 	app.Flags = append(app.Flags, debug.Flags...)
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -160,6 +160,7 @@ participating.
 		utils.RaftModeFlag,
 		utils.RaftBlockTimeFlag,
 		utils.RaftJoinExistingFlag,
+		utils.RaftPortFlag,
 	}
 	app.Flags = append(app.Flags, debug.Flags...)
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -94,6 +94,14 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "RAFT",
+		Flags: []cli.Flag{
+			utils.RaftModeFlag,
+			utils.RaftBlockTimeFlag,
+			utils.RaftJoinExistingFlag,
+		},
+	},
+	{
 		Name: "ACCOUNT",
 		Flags: []cli.Flag{
 			utils.UnlockedAccountFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -99,6 +99,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RaftModeFlag,
 			utils.RaftBlockTimeFlag,
 			utils.RaftJoinExistingFlag,
+			utils.RaftPortFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -50,7 +50,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv2"
 	"gopkg.in/urfave/cli.v1"
-	"log"
 )
 
 func init() {
@@ -746,8 +745,11 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 			if joinExistingId > 0 {
 				myId = uint16(joinExistingId)
 				joinExisting = true
+			} else if len(peers) == 0 {
+				Fatalf("Raft-based consensus requires either (1) an initial peers list (in static-nodes.json) including this enode hash (%v), or (2) the flag --raftjoinexisting RAFT_ID, where RAFT_ID has been issued by an existing cluster member calling `raft.addPeer(ENODE_ID)` with an enode ID containing this node's enode hash.", strId)
 			} else {
 				peerIds := make([]string, len(peers))
+
 				for peerIdx, peer := range peers {
 					peerId := peer.ID.String()
 					peerIds[peerIdx] = peerId
@@ -757,7 +759,7 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 				}
 
 				if myId == 0 {
-					log.Panicf("failed to find local enode ID (%v) amongst peer IDs: %v", strId, peerIds)
+					Fatalf("failed to find local enode ID (%v) amongst peer IDs: %v", strId, peerIds)
 				}
 			}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -380,7 +380,7 @@ var (
 		Name:  "raft",
 		Usage: "If enabled, uses Raft instead of Quorum Chain for consensus",
 	}
-	RaftBlockTime = cli.IntFlag{
+	RaftBlockTimeFlag = cli.IntFlag{
 		Name:  "raftblocktime",
 		Usage: "Amount of time between raft block creations in milliseconds",
 		Value: 50,
@@ -729,7 +729,7 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 	}
 
 	if ctx.GlobalBool(RaftModeFlag.Name) {
-		blockTimeMillis := ctx.GlobalInt(RaftBlockTime.Name)
+		blockTimeMillis := ctx.GlobalInt(RaftBlockTimeFlag.Name)
 		datadir := ctx.GlobalString(DataDirFlag.Name)
 		joinExistingId := ctx.GlobalInt(RaftJoinExistingFlag.Name)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -757,7 +757,7 @@ func RegisterEthService(ctx *cli.Context, stack *node.Node, extra []byte) {
 				peerIds := make([]string, len(peers))
 
 				for peerIdx, peer := range peers {
-					if peer.RaftPort == 0 {
+					if !peer.HasRaftPort() {
 						Fatalf("raftport querystring parameter not specified in static-node enode ID: %v. please check your static-nodes.json file.", peer.String())
 					}
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -369,6 +369,13 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 	if p == nil {
 		return errUnknownPeer
 	}
+	if d.mode == BoundedFullSync {
+		err := d.syncWithPeerUntil(p, hash, td)
+		if err == nil {
+			d.processContent()
+		}
+		return err
+	}
 	return d.syncWithPeer(p, hash, td)
 }
 
@@ -1292,7 +1299,7 @@ func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
 					}
 				}
 				// Unless we're doing light chains, schedule the headers for associated content retrieval
-				if d.mode == FullSync || d.mode == FastSync {
+				if d.mode == FullSync || d.mode == FastSync || d.mode == BoundedFullSync {
 					// If we've reached the allowed number of pending headers, stall a bit
 					for d.queue.PendingBlocks() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders {
 						select {
@@ -1354,7 +1361,7 @@ func (d *Downloader) processContent() error {
 			items := int(math.Min(float64(len(results)), float64(maxResultsProcess)))
 			for _, result := range results[:items] {
 				switch {
-				case d.mode == FullSync:
+				case d.mode == FullSync || d.mode == BoundedFullSync:
 					blocks = append(blocks, types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles))
 				case d.mode == FastSync:
 					blocks = append(blocks, types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles))
@@ -1502,4 +1509,212 @@ func (d *Downloader) requestTTL() time.Duration {
 		ttl = ttlLimit
 	}
 	return ttl
+}
+
+// Extra downloader functionality for non-proof-of-work consensus
+
+// Synchronizes with a peer, but only up to the provided Hash
+func (d *Downloader) syncWithPeerUntil(p *peer, hash common.Hash, td *big.Int) (err error) {
+	d.mux.Post(StartEvent{})
+	defer func() {
+		// reset on error
+		if err != nil {
+			d.mux.Post(FailedEvent{err})
+		} else {
+			d.mux.Post(DoneEvent{})
+		}
+	}()
+	if p.version < 62 {
+		return errTooOld
+	}
+
+	glog.V(logger.Debug).Infof("Synchronising with the network using: %s [eth/%d]", p.id, p.version)
+	defer func(start time.Time) {
+		glog.V(logger.Debug).Infof("Synchronisation terminated after %v", time.Since(start))
+	}(time.Now())
+
+	remoteHeader, err := d.fetchHeader(p, hash)
+	if err != nil {
+		return err
+	}
+
+	remoteHeight := remoteHeader.Number.Uint64()
+	localHeight := d.headBlock().NumberU64()
+
+	d.syncStatsLock.Lock()
+	if d.syncStatsChainHeight <= localHeight || d.syncStatsChainOrigin > localHeight {
+		d.syncStatsChainOrigin = localHeight
+	}
+	d.syncStatsChainHeight = remoteHeight
+	d.syncStatsLock.Unlock()
+
+	d.queue.Prepare(localHeight+1, d.mode, uint64(0), remoteHeader)
+	if d.syncInitHook != nil {
+		d.syncInitHook(localHeight, remoteHeight)
+	}
+	return d.spawnSync(localHeight+1,
+		func() error { return d.fetchBoundedHeaders(p, localHeight+1, remoteHeight) },
+		func() error { return d.processHeaders(localHeight+1, td) },
+		func() error { return d.fetchBodies(localHeight + 1) },
+		func() error { return d.fetchReceipts(localHeight + 1) }, // Receipts are only retrieved during fast sync
+		func() error { return d.fetchNodeData() },                // Node state data is only retrieved during fast sync
+	)
+}
+
+// Fetches a single header from a peer
+func (d *Downloader) fetchHeader(p *peer, hash common.Hash) (*types.Header, error) {
+	glog.V(logger.Debug).Infof("%v: retrieving remote chain height", p)
+
+	go p.getRelHeaders(hash, 1, 0, false)
+
+	timeout := time.After(d.requestTTL())
+	for {
+		select {
+		case <-d.cancelCh:
+			return nil, errCancelBlockFetch
+
+		case packet := <-d.headerCh:
+			// Discard anything not from the origin peer
+			if packet.PeerId() != p.id {
+				glog.V(logger.Debug).Infof("Received headers from incorrect peer(%s)", packet.PeerId())
+				break
+			}
+			// Make sure the peer actually gave something valid
+			headers := packet.(*headerPack).headers
+			if len(headers) != 1 {
+				glog.V(logger.Debug).Infof("%v: invalid number of head headers: %d != 1", p, len(headers))
+				return nil, errBadPeer
+			}
+			return headers[0], nil
+
+		case <-timeout:
+			glog.V(logger.Debug).Infof("%v: head header timeout", p)
+			return nil, errTimeout
+
+		case <-d.bodyCh:
+		case <-d.stateCh:
+		case <-d.receiptCh:
+			// Out of bounds delivery, ignore
+		}
+	}
+}
+
+// Not defined in go's stdlib:
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Fetches headers between `from` and `to`, inclusive.
+// Assumes invariant: from <= to.
+func (d *Downloader) fetchBoundedHeaders(p *peer, from uint64, to uint64) error {
+	glog.V(logger.Debug).Infof("%v: directing header downloads from #%d to #%d", p, from, to)
+	defer glog.V(logger.Debug).Infof("%v: header download terminated", p)
+
+	// Create a timeout timer, and the associated header fetcher
+	skeleton := true            // Skeleton assembly phase or finishing up
+	request := time.Now()       // time of the last skeleton fetch request
+	timeout := time.NewTimer(0) // timer to dump a non-responsive active peer
+	<-timeout.C                 // timeout channel should be initially empty
+	defer timeout.Stop()
+
+	getHeaders := func(from uint64) {
+		request = time.Now()
+		timeout.Reset(d.requestTTL())
+
+		skeletonStart := from + uint64(MaxHeaderFetch) - 1
+
+		if skeleton {
+			if skeletonStart > to {
+				skeleton = false
+			}
+		}
+
+		if skeleton {
+			numSkeletonHeaders := minInt(MaxSkeletonSize, (int(to-from)+1)/MaxHeaderFetch)
+			glog.V(logger.Detail).Infof("%v: fetching %d skeleton headers from #%d", p, numSkeletonHeaders, from)
+			go p.getAbsHeaders(skeletonStart, numSkeletonHeaders, MaxHeaderFetch-1, false)
+		} else {
+			// There are not enough headers remaining to warrant a skeleton fetch.
+			// Grab all of the remaining headers.
+
+			numHeaders := int(to-from) + 1
+			glog.V(logger.Detail).Infof("%v: fetching %d full headers from #%d", p, numHeaders, from)
+			go p.getAbsHeaders(from, numHeaders, 0, false)
+		}
+	}
+	// Start pulling the header chain skeleton until all is done
+	getHeaders(from)
+
+	for {
+		select {
+		case <-d.cancelCh:
+			return errCancelHeaderFetch
+
+		case packet := <-d.headerCh:
+			// Make sure the active peer is giving us the skeleton headers
+			if packet.PeerId() != p.id {
+				glog.V(logger.Debug).Infof("Received headers from incorrect peer (%s)", packet.PeerId())
+				break
+			}
+			headerReqTimer.UpdateSince(request)
+			timeout.Stop()
+
+			headers := packet.(*headerPack).headers
+
+			// If we received a skeleton batch, resolve internals concurrently
+			if skeleton {
+				filled, proced, err := d.fillHeaderSkeleton(from, headers)
+				if err != nil {
+					glog.V(logger.Debug).Infof("%v: skeleton chain invalid: %v", p, err)
+					return errInvalidChain
+				}
+				headers = filled[proced:]
+				from += uint64(proced)
+			}
+			// Insert all the new headers and fetch the next batch
+			if len(headers) > 0 {
+				glog.V(logger.Detail).Infof("%v: schedule %d headers from #%d", p, len(headers), from)
+				select {
+				case d.headerProcCh <- headers:
+				case <-d.cancelCh:
+					return errCancelHeaderFetch
+				}
+				from += uint64(len(headers))
+			}
+
+			if from <= to {
+				getHeaders(from)
+			} else {
+				// Notify the content fetchers that no more headers are inbound and return.
+				select {
+				case d.headerProcCh <- nil:
+					return nil
+				case <-d.cancelCh:
+					return errCancelHeaderFetch
+				}
+			}
+
+		case <-timeout.C:
+			// Header retrieval timed out, consider the peer bad and drop
+			glog.V(logger.Debug).Infof("%v: header request timed out", p)
+			headerTimeoutMeter.Mark(1)
+			d.dropPeer(p.id)
+
+			// Finish the sync gracefully instead of dumping the gathered data though
+			for _, ch := range []chan bool{d.bodyWakeCh, d.receiptWakeCh, d.stateWakeCh} {
+				select {
+				case ch <- false:
+				case <-d.cancelCh:
+				}
+			}
+			select {
+			case d.headerProcCh <- nil:
+			case <-d.cancelCh:
+			}
+			return errBadPeer
+		}
+	}
 }

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -23,4 +23,6 @@ const (
 	FullSync  SyncMode = iota // Synchronise the entire blockchain history from full blocks
 	FastSync                  // Quickly download the headers, full sync only at the chain head
 	LightSync                 // Download only the headers and terminate afterwards
+	// Used by raft:
+	BoundedFullSync SyncMode = 100 // Perform a full sync until the requested hash, and no further
 )

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -326,8 +326,12 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 	defer msg.Discard()
 
 	if pm.raftMode {
-		if msg.Code != TxMsg {
-			glog.V(logger.Debug).Infof("raft: ignoring non-TxMsg with code %v", msg.Code)
+		if msg.Code != TxMsg &&
+			msg.Code != GetBlockHeadersMsg && msg.Code != BlockHeadersMsg &&
+			msg.Code != GetBlockBodiesMsg && msg.Code != BlockBodiesMsg {
+
+			glog.V(logger.Warn).Infof("raft: ignoring message with code %v", msg.Code)
+
 			return nil
 		}
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -744,7 +744,11 @@ func (pm *ProtocolManager) BroadcastBlock(block *types.Block, propagate bool) {
 func (pm *ProtocolManager) BroadcastTx(hash common.Hash, tx *types.Transaction) {
 	// Broadcast transaction to a batch of peers not knowing about it
 	peers := pm.peers.PeersWithoutTx(hash)
-	//FIXME include this again: peers = peers[:int(math.Sqrt(float64(len(peers))))]
+	// NOTE: Raft-based consensus currently assumes that geth broadcasts
+	// transactions to all peers in the network. A previous comment here
+	// indicated that this logic might change in the future to only send to a
+	// subset of peers. If this change occurs upstream, a merge conflict should
+	// arise here, and we should add logic to send to *all* peers in raft mode.
 	for _, peer := range peers {
 		peer.SendTransactions(types.Transactions{tx})
 	}

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -146,11 +146,15 @@ func (pm *ProtocolManager) syncer() {
 			if pm.peers.Len() < minDesiredPeerCount {
 				break
 			}
-			go pm.synchronise(pm.peers.BestPeer())
+			if !pm.raftMode {
+				go pm.synchronise(pm.peers.BestPeer())
+			}
 
 		case <-forceSync:
-			// Force a sync even if not enough peers are present
-			go pm.synchronise(pm.peers.BestPeer())
+			if !pm.raftMode {
+				// Force a sync even if not enough peers are present
+				go pm.synchronise(pm.peers.BestPeer())
+			}
 
 		case <-pm.noMorePeers:
 			return

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -528,7 +528,7 @@ web3._extend({
                new web3._extend.Method({
                        name: 'addPeer',
                        call: 'raft_addPeer',
-                       params: 2
+                       params: 1
                }),
                new web3._extend.Method({
                        name: 'removePeer',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -524,6 +524,16 @@ web3._extend({
                new web3._extend.Property({
                        name: 'role',
                        getter: 'raft_role'
+               }),
+               new web3._extend.Method({
+                       name: 'addPeer',
+                       call: 'raft_addPeer',
+                       params: 2
+               }),
+               new web3._extend.Method({
+                       name: 'removePeer',
+                       call: 'raft_removePeer',
+                       params: 1
                })
        ]
 })

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -114,7 +114,7 @@ func (n *Node) String() string {
 			u.RawQuery = "discport=" + strconv.Itoa(int(n.UDP))
 		}
 
-		if n.RaftPort > 0 {
+		if n.HasRaftPort() {
 			raftQuery := "raftport=" + strconv.Itoa(int(n.RaftPort))
 			if len(u.RawQuery) > 0 {
 				u.RawQuery = u.RawQuery + "&" + raftQuery
@@ -124,6 +124,10 @@ func (n *Node) String() string {
 		}
 	}
 	return u.String()
+}
+
+func (n *Node) HasRaftPort() bool {
+	return n.RaftPort > 0
 }
 
 var incompleteNodeURL = regexp.MustCompile("(?i)^(?:enode://)?([0-9a-f]+)$")

--- a/p2p/discover/node.go
+++ b/p2p/discover/node.go
@@ -44,6 +44,8 @@ type Node struct {
 	UDP, TCP uint16 // port numbers
 	ID       NodeID // the node's public key
 
+	RaftPort uint16
+
 	// This is a cached copy of sha3(ID) which is used for node
 	// distance calculations. This is part of Node in order to make it
 	// possible to write tests that need a node at a certain distance.
@@ -110,6 +112,15 @@ func (n *Node) String() string {
 		u.Host = addr.String()
 		if n.UDP != n.TCP {
 			u.RawQuery = "discport=" + strconv.Itoa(int(n.UDP))
+		}
+
+		if n.RaftPort > 0 {
+			raftQuery := "raftport=" + strconv.Itoa(int(n.RaftPort))
+			if len(u.RawQuery) > 0 {
+				u.RawQuery = u.RawQuery + "&" + raftQuery
+			} else {
+				u.RawQuery = raftQuery
+			}
 		}
 	}
 	return u.String()
@@ -195,7 +206,17 @@ func parseComplete(rawurl string) (*Node, error) {
 			return nil, errors.New("invalid discport in query")
 		}
 	}
-	return NewNode(id, ip, uint16(udpPort), uint16(tcpPort)), nil
+
+	node := NewNode(id, ip, uint16(udpPort), uint16(tcpPort))
+
+	if qv.Get("raftport") != "" {
+		raftPort, err := strconv.ParseUint(qv.Get("raftport"), 10, 16)
+		if err != nil {
+			return nil, errors.New("invalid raftport in query")
+		}
+		node.RaftPort = uint16(raftPort)
+	}
+	return node, nil
 }
 
 // MustParseNode parses a node URL. It panics if the URL is not valid.

--- a/raft/api.go
+++ b/raft/api.go
@@ -1,5 +1,15 @@
 package raft
 
+type RaftNodeInfo struct {
+	ClusterSize    int        `json:"clusterSize"`
+	Role           string     `json:"role"`
+	Address        *Address   `json:"address"`
+	PeerAddresses  []*Address `json:"peerAddresses"`
+	RemovedPeerIds []uint16   `json:"removedPeerIds"`
+	AppliedIndex   uint64     `json:"appliedIndex"`
+	SnapshotIndex  uint64     `json:"snapshotIndex"`
+}
+
 type PublicRaftAPI struct {
 	raftService *RaftService
 }

--- a/raft/api.go
+++ b/raft/api.go
@@ -9,10 +9,5 @@ func NewPublicRaftAPI(raftService *RaftService) *PublicRaftAPI {
 }
 
 func (s *PublicRaftAPI) Role() string {
-	role := s.raftService.raftProtocolManager.role
-	if role == minterRole {
-		return "minter"
-	} else {
-		return "verifier"
-	}
+	return s.raftService.raftProtocolManager.NodeInfo().Role
 }

--- a/raft/api.go
+++ b/raft/api.go
@@ -11,3 +11,11 @@ func NewPublicRaftAPI(raftService *RaftService) *PublicRaftAPI {
 func (s *PublicRaftAPI) Role() string {
 	return s.raftService.raftProtocolManager.NodeInfo().Role
 }
+
+func (s *PublicRaftAPI) AddPeer(raftId uint16, enodeId string) error {
+	return s.raftService.raftProtocolManager.ProposeNewPeer(raftId, enodeId)
+}
+
+func (s *PublicRaftAPI) RemovePeer(raftId uint16) {
+	s.raftService.raftProtocolManager.ProposePeerRemoval(raftId)
+}

--- a/raft/api.go
+++ b/raft/api.go
@@ -22,8 +22,8 @@ func (s *PublicRaftAPI) Role() string {
 	return s.raftService.raftProtocolManager.NodeInfo().Role
 }
 
-func (s *PublicRaftAPI) AddPeer(raftId uint16, enodeId string) error {
-	return s.raftService.raftProtocolManager.ProposeNewPeer(raftId, enodeId)
+func (s *PublicRaftAPI) AddPeer(enodeId string) (uint16, error) {
+	return s.raftService.raftProtocolManager.ProposeNewPeer(enodeId)
 }
 
 func (s *PublicRaftAPI) RemovePeer(raftId uint16) {

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -85,8 +85,8 @@ func (service *RaftService) APIs() []rpc.API {
 
 // Start implements node.Service, starting the background data propagation thread
 // of the protocol.
-func (service *RaftService) Start(*p2p.Server) error {
-	service.raftProtocolManager.Start()
+func (service *RaftService) Start(p2pServer *p2p.Server) error {
+	service.raftProtocolManager.Start(p2pServer)
 	return nil
 }
 

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -49,8 +49,8 @@ func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16,
 		blockchain:     e.BlockChain(),
 		txPool:         e.TxPool(),
 		accountManager: e.AccountManager(),
-		downloader: e.Downloader(),
-		startPeers: startPeers,
+		downloader:     e.Downloader(),
+		startPeers:     startPeers,
 	}
 
 	service.minter = newMinter(chainConfig, service, blockTime)
@@ -98,6 +98,7 @@ func (service *RaftService) Start(p2pServer *p2p.Server) error {
 func (service *RaftService) Stop() error {
 	service.blockchain.Stop()
 	service.raftProtocolManager.Stop()
+	service.minter.stop()
 	service.eventMux.Stop()
 
 	service.chainDb.Close()

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -33,13 +32,6 @@ type RaftService struct {
 	// we need an event mux to instantiate the blockchain
 	eventMux *event.TypeMux
 	minter   *minter
-}
-
-type RaftNodeInfo struct {
-	ClusterSize int         `json:"clusterSize"`
-	Genesis     common.Hash `json:"genesis"` // SHA3 hash of the host's genesis block
-	Head        common.Hash `json:"head"`    // SHA3 hash of the host's best owned block
-	Role        string      `json:"role"`
 }
 
 func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*discover.Node, datadir string) (*RaftService, error) {

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -40,7 +40,7 @@ type RaftNodeInfo struct {
 	Role        string      `json:"role"`
 }
 
-func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, id int, blockTime time.Duration, e *eth.Ethereum, startPeers []*discover.Node, datadir string) (*RaftService, error) {
+func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*discover.Node, datadir string) (*RaftService, error) {
 	service := &RaftService{
 		eventMux:       ctx.EventMux,
 		chainDb:        e.ChainDb(),
@@ -53,7 +53,7 @@ func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, id int, blockT
 	service.minter = newMinter(chainConfig, service, blockTime)
 
 	var err error
-	if service.raftProtocolManager, err = NewProtocolManager(id, service.blockchain, service.eventMux, startPeers, datadir, service.minter); err != nil {
+	if service.raftProtocolManager, err = NewProtocolManager(raftId, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter); err != nil {
 		return nil, err
 	}
 

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/logger"
@@ -24,6 +25,7 @@ type RaftService struct {
 	txMu           sync.Mutex
 	txPool         *core.TxPool
 	accountManager *accounts.Manager
+	downloader     *downloader.Downloader
 
 	raftProtocolManager *ProtocolManager
 	startPeers          []*discover.Node
@@ -47,13 +49,14 @@ func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16,
 		blockchain:     e.BlockChain(),
 		txPool:         e.TxPool(),
 		accountManager: e.AccountManager(),
-		startPeers:     startPeers,
+		downloader: e.Downloader(),
+		startPeers: startPeers,
 	}
 
 	service.minter = newMinter(chainConfig, service, blockTime)
 
 	var err error
-	if service.raftProtocolManager, err = NewProtocolManager(raftId, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter); err != nil {
+	if service.raftProtocolManager, err = NewProtocolManager(raftId, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter, service.downloader); err != nil {
 		return nil, err
 	}
 

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -34,7 +34,7 @@ type RaftService struct {
 	minter   *minter
 }
 
-func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*discover.Node, datadir string) (*RaftService, error) {
+func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16, raftPort uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*discover.Node, datadir string) (*RaftService, error) {
 	service := &RaftService{
 		eventMux:       ctx.EventMux,
 		chainDb:        e.ChainDb(),
@@ -48,7 +48,7 @@ func New(ctx *node.ServiceContext, chainConfig *core.ChainConfig, raftId uint16,
 	service.minter = newMinter(chainConfig, service, blockTime)
 
 	var err error
-	if service.raftProtocolManager, err = NewProtocolManager(raftId, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter, service.downloader); err != nil {
+	if service.raftProtocolManager, err = NewProtocolManager(raftId, raftPort, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter, service.downloader); err != nil {
 		return nil, err
 	}
 

--- a/raft/constants.go
+++ b/raft/constants.go
@@ -26,6 +26,8 @@ const (
 	snapshotPeriod = 250
 
 	peerUrlKeyPrefix = "peerUrl-"
+
+	chainExtensionMessage = "Successfully extended chain"
 )
 
 var (

--- a/raft/doc.md
+++ b/raft/doc.md
@@ -6,8 +6,6 @@ This directory holds an implementation of a [Raft](https://raft.github.io)-based
 
 When the `geth` binary is passed the `--raft` flag, the node will operate in "raft mode."
 
-Currently Raft-based consensus requires that all nodes in the cluster are configured to list the others up-front as [static peers](https://github.com/ethereum/go-ethereum/wiki/Connecting-to-the-network#static-nodes). We will be adding support for dynamic membership changes in the near future.
-
 ## Some implementation basics
 
 Note: Though we use the etcd implementation of the Raft protocol, we speak of "Raft" more broadly to refer to the Raft protocol, and its use to achieve consensus for Quorum/Ethereum.
@@ -145,6 +143,14 @@ There is currently no limit to the length of these speculative chains, but we pl
 ## The Raft transport layer
 
 We communicate blocks over the HTTP transport layer built in to etcd Raft. It's also (at least theoretically) possible to use p2p protocol built-in to Ethereum as a transport for Raft. In our testing we found the default etcd HTTP transport to be more reliable than the p2p (at least as implemented in geth) under high load.
+
+## Initial configuration, and enacting membership changes
+
+Currently Raft-based consensus requires that all _initial_ nodes in the cluster are configured to list the others up-front as [static peers](https://github.com/ethereum/go-ethereum/wiki/Connecting-to-the-network#static-nodes).
+
+To remove a node from the cluster, attach to a JS console and issue `raft.removePeer(raftId)`, where `raftId` is the number of the node you wish to remove. Once a node has been removed from the cluster, it is permanent; this raft ID can not ever re-connect to the cluster in the future, and the party must re-join the cluster with a new raft ID.
+
+To add a node to the cluster, attach to a JS console and issue `raft.addPeer(raftId, enodeId)`. Here, `raftId` must be a raft ID that is not currently in use. Then start the new geth node with the flag `--raftjoinexisting RAFTID` in addition to `--raft`.
 
 ## FAQ
 

--- a/raft/doc.md
+++ b/raft/doc.md
@@ -148,9 +148,9 @@ We communicate blocks over the HTTP transport layer built in to etcd Raft. It's 
 
 Currently Raft-based consensus requires that all _initial_ nodes in the cluster are configured to list the others up-front as [static peers](https://github.com/ethereum/go-ethereum/wiki/Connecting-to-the-network#static-nodes).
 
-To remove a node from the cluster, attach to a JS console and issue `raft.removePeer(raftId)`, where `raftId` is the number of the node you wish to remove. Once a node has been removed from the cluster, it is permanent; this raft ID can not ever re-connect to the cluster in the future, and the party must re-join the cluster with a new raft ID.
+To remove a node from the cluster, attach to a JS console and issue `raft.removePeer(raftId)`, where `raftId` is the number of the node you wish to remove. For initial nodes in the cluster, this number is the 1-indexed position of the node's enode ID in the static peers list. Once a node has been removed from the cluster, it is permanent; this raft ID can not ever re-connect to the cluster in the future, and the party must re-join the cluster with a new raft ID.
 
-To add a node to the cluster, attach to a JS console and issue `raft.addPeer(raftId, enodeId)`. Here, `raftId` must be a raft ID that is not currently in use. Then start the new geth node with the flag `--raftjoinexisting RAFTID` in addition to `--raft`.
+To add a node to the cluster, attach to a JS console and issue `raft.addPeer(enodeId)`. This call will allocate and return a raft ID that was not already in use. After `addPeer`, start the new geth node with the flag `--raftjoinexisting RAFTID` in addition to `--raft`.
 
 ## FAQ
 

--- a/raft/doc.md
+++ b/raft/doc.md
@@ -144,13 +144,15 @@ There is currently no limit to the length of these speculative chains, but we pl
 
 We communicate blocks over the HTTP transport layer built in to etcd Raft. It's also (at least theoretically) possible to use p2p protocol built-in to Ethereum as a transport for Raft. In our testing we found the default etcd HTTP transport to be more reliable than the p2p (at least as implemented in geth) under high load.
 
+Quorum listens on port 50400 by default for the raft transport, but this is configurable with the `--raftport` flag.
+
 ## Initial configuration, and enacting membership changes
 
-Currently Raft-based consensus requires that all _initial_ nodes in the cluster are configured to list the others up-front as [static peers](https://github.com/ethereum/go-ethereum/wiki/Connecting-to-the-network#static-nodes).
+Currently Raft-based consensus requires that all _initial_ nodes in the cluster are configured to list the others up-front as [static peers](https://github.com/ethereum/go-ethereum/wiki/Connecting-to-the-network#static-nodes). These enode ID URIs _must_ include a `raftport` querystring parameter specifying the raft port for each peer: e.g. `enode://abcd@127.0.0.1:30400?raftport=50400`.
 
 To remove a node from the cluster, attach to a JS console and issue `raft.removePeer(raftId)`, where `raftId` is the number of the node you wish to remove. For initial nodes in the cluster, this number is the 1-indexed position of the node's enode ID in the static peers list. Once a node has been removed from the cluster, it is permanent; this raft ID can not ever re-connect to the cluster in the future, and the party must re-join the cluster with a new raft ID.
 
-To add a node to the cluster, attach to a JS console and issue `raft.addPeer(enodeId)`. This call will allocate and return a raft ID that was not already in use. After `addPeer`, start the new geth node with the flag `--raftjoinexisting RAFTID` in addition to `--raft`.
+To add a node to the cluster, attach to a JS console and issue `raft.addPeer(enodeId)`. Note that like the enode IDs listed in the static peers JSON file, this enode ID should include a `raftport` querystring parameter. This call will allocate and return a raft ID that was not already in use. After `addPeer`, start the new geth node with the flag `--raftjoinexisting RAFTID` in addition to `--raft`.
 
 ## FAQ
 

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -357,11 +357,13 @@ func (pm *ProtocolManager) startRaft() {
 	// We load the snapshot to connect to prev peers before replaying the WAL,
 	// which typically goes further into the future than the snapshot.
 
+	var maybeRaftSnapshot *raftpb.Snapshot
+
 	if walExisted {
-		pm.loadSnapshot() // re-establishes peer connections
+		maybeRaftSnapshot = pm.loadSnapshot() // re-establishes peer connections
 	}
 
-	pm.wal = pm.replayWAL()
+	pm.wal = pm.replayWAL(maybeRaftSnapshot)
 
 	if walExisted {
 		if hardState, _, err := pm.raftStorage.InitialState(); err != nil {

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -239,11 +239,7 @@ func (pm *ProtocolManager) Process(ctx context.Context, m raftpb.Message) error 
 }
 
 func (pm *ProtocolManager) IsIDRemoved(id uint64) bool {
-	// TODO: implement this in the future once we support dynamic cluster membership
-
-	glog.V(logger.Info).Infof("reporting that raft ID %d is not removed", id)
-
-	return false
+	return pm.peers[uint16(id)] == nil
 }
 
 func (pm *ProtocolManager) ReportUnreachable(id uint64) {

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -556,7 +556,7 @@ func (pm *ProtocolManager) eventLoop() {
 
 			pm.maybeTriggerSnapshot()
 
-			if (exitAfterApplying) {
+			if exitAfterApplying {
 				glog.V(logger.Warn).Infoln("removing self from the cluster due to ConfChangeRemoveNode")
 				syscall.Exit(0)
 			}

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -58,7 +58,6 @@ type ProtocolManager struct {
 
 	// set of currently active peers known to the raft cluster. this includes self
 	raftPeers []etcdRaft.Peer
-	peerUrls  []string
 	p2pNodes  []*discover.Node
 	p2pServer *p2p.Server // Initialized in start()
 
@@ -120,10 +119,8 @@ func NewProtocolManager(id int, blockchain *core.BlockChain, mux *event.TypeMux,
 	snapdir := fmt.Sprintf("%s/raft-snap", datadir)
 	quorumRaftDbLoc := fmt.Sprintf("%s/quorum-raft-state", datadir)
 
-	peerUrls := makePeerUrls(peers)
 	manager := &ProtocolManager{
-		raftPeers:   makeRaftPeers(peerUrls),
-		peerUrls:    peerUrls,
+		raftPeers:   makeRaftPeers(makePeerUrls(peers)),
 		p2pNodes:    peers,
 		blockchain:  blockchain,
 		eventMux:    mux,

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -487,12 +487,14 @@ func (pm *ProtocolManager) addPeer(address *Address) {
 
 func (pm *ProtocolManager) removePeer(raftId uint16) {
 	pm.mu.Lock()
-	peer := pm.peers[raftId]
-	delete(pm.peers, raftId)
-	pm.mu.Unlock()
+	defer pm.mu.Unlock()
 
-	pm.p2pServer.RemovePeer(peer.p2pNode)
-	pm.transport.RemovePeer(raftTypes.ID(raftId))
+	if peer := pm.peers[raftId]; peer != nil {
+		pm.p2pServer.RemovePeer(peer.p2pNode)
+		pm.transport.RemovePeer(raftTypes.ID(raftId))
+
+		delete(pm.peers, raftId)
+	}
 }
 
 func (pm *ProtocolManager) reconnectToPreviousPeers() {

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -200,6 +200,30 @@ func (pm *ProtocolManager) NodeInfo() *RaftNodeInfo {
 	}
 }
 
+func (pm *ProtocolManager) nextRaftId() uint16 {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	maxId := pm.raftId
+
+	for peerId := range pm.peers {
+		if maxId < peerId {
+			maxId = peerId
+		}
+	}
+
+	removedPeerIfaces := pm.removedPeers.List()
+	for _, removedIface := range removedPeerIfaces {
+		removedId := removedIface.(uint16)
+
+		if maxId < removedId {
+			maxId = removedId
+		}
+	}
+
+	return maxId + 1
+}
+
 func (pm *ProtocolManager) ProposeNewPeer(raftId uint16, enodeId string) error {
 	node, err := discover.ParseNode(enodeId)
 	if err != nil {

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -560,6 +560,7 @@ func (pm *ProtocolManager) eventLoop() {
 			if snap := rd.Snapshot; !etcdRaft.IsEmptySnap(snap) {
 				pm.saveRaftSnapshot(snap)
 				pm.applyRaftSnapshot(snap)
+				pm.advanceAppliedIndex(snap.Metadata.Index)
 			}
 
 			// 1: Write HardState, Entries, and Snapshot to persistent storage if they

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -248,11 +248,17 @@ func (pm *ProtocolManager) IsIDRemoved(id uint64) bool {
 
 func (pm *ProtocolManager) ReportUnreachable(id uint64) {
 	glog.V(logger.Warn).Infof("peer %d is currently unreachable", id)
+
 	pm.rawNode.ReportUnreachable(id)
 }
 
 func (pm *ProtocolManager) ReportSnapshot(id uint64, status etcdRaft.SnapshotStatus) {
-	glog.V(logger.Info).Infof("status of last-sent snapshot: %v", status)
+	if status == etcdRaft.SnapshotFailure {
+		glog.V(logger.Info).Infof("failed to send snapshot to raft peer %v", id)
+	} else if status == etcdRaft.SnapshotFinish {
+		glog.V(logger.Info).Infof("finished sending snapshot to raft peer %v", id)
+	}
+
 	pm.rawNode.ReportSnapshot(id, status)
 }
 

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -194,6 +194,10 @@ func (pm *ProtocolManager) ProposeNewPeer(raftId uint16, enodeId string) error {
 		return err
 	}
 
+	if len(node.IP) != 4 {
+		return fmt.Errorf("expected IPv4 address (with length 4), but got IP of length %v", len(node.IP))
+	}
+
 	address := &Address{
 		raftId:   raftId,
 		nodeId:   node.ID,

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -561,11 +561,11 @@ func (pm *ProtocolManager) eventLoop() {
 					case raftpb.ConfChangeAddNode:
 						glog.V(logger.Info).Infof("adding peer %v due to ConfChangeAddNode", cc.NodeID)
 
-						if nodeRaftId := uint16(cc.NodeID); nodeRaftId != pm.raftId {
-							address := bytesToAddress(cc.Context)
-							pm.addPeer(address)
+						nodeRaftId := uint16(cc.NodeID)
+						pm.writePeerAddressBytes(nodeRaftId, cc.Context)
 
-							pm.writePeerAddressBytes(nodeRaftId, cc.Context)
+						if nodeRaftId != pm.raftId {
+							pm.addPeer(bytesToAddress(cc.Context))
 						}
 
 					case raftpb.ConfChangeRemoveNode:

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -133,8 +133,8 @@ func (pm *ProtocolManager) Start(p2pServer *p2p.Server) {
 
 	pm.p2pServer = p2pServer
 	pm.minedBlockSub = pm.eventMux.Subscribe(core.NewMinedBlockEvent{})
-	go pm.minedBroadcastLoop()
 	pm.startRaft()
+	go pm.minedBroadcastLoop()
 }
 
 func (pm *ProtocolManager) Stop() {

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -299,13 +299,12 @@ func (pm *ProtocolManager) ProposeNewPeer(enodeId string) (uint16, error) {
 		return 0, fmt.Errorf("expected IPv4 address (with length 4), but got IP of length %v", len(node.IP))
 	}
 
-	raftPort := node.RaftPort
-	if raftPort == 0 {
+	if !node.HasRaftPort() {
 		return 0, fmt.Errorf("enodeId is missing raftport querystring parameter: %v", enodeId)
 	}
 
 	raftId := pm.nextRaftId()
-	address := newAddress(raftId, raftPort, node)
+	address := newAddress(raftId, node.RaftPort, node)
 
 	pm.confChangeProposalC <- raftpb.ConfChange{
 		Type:    raftpb.ConfChangeAddNode,

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -1,0 +1,70 @@
+package raft
+
+import (
+	"io"
+	"net"
+
+	"fmt"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/rlp"
+	"log"
+)
+
+// Serializable information about a Peer. Sufficient to build `etcdRaft.Peer`
+// or `discover.Node`.
+type Address struct {
+	raftId   uint16
+	nodeId   discover.NodeID
+	ip       net.IP
+	p2pPort  uint16
+	raftPort uint16
+}
+
+// A peer that we're connected to via both raft's http transport, and ethereum p2p
+type Peer struct {
+	address *Address
+	p2pNode *discover.Node
+}
+
+func (addr *Address) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{addr.raftId, addr.nodeId, addr.ip, addr.p2pPort, addr.raftPort})
+}
+
+func (addr *Address) DecodeRLP(s *rlp.Stream) error {
+	// These fields need to be public:
+	var temp struct {
+		RaftId   uint16
+		NodeId   discover.NodeID
+		Ip       net.IP
+		P2pPort  uint16
+		RaftPort uint16
+	}
+
+	if err := s.Decode(&temp); err != nil {
+		return err
+	} else {
+		addr.raftId, addr.nodeId, addr.ip, addr.p2pPort, addr.raftPort = temp.RaftId, temp.NodeId, temp.Ip, temp.P2pPort, temp.RaftPort
+		return nil
+	}
+}
+
+// RLP Address encoding, for transport over raft and storage in LevelDB.
+
+func (addr *Address) toBytes() []byte {
+	size, r, err := rlp.EncodeToReader(addr)
+	if err != nil {
+		panic(fmt.Sprintf("error: failed to RLP-encode Address: %s", err.Error()))
+	}
+	var buffer = make([]byte, uint32(size))
+	r.Read(buffer)
+
+	return buffer
+}
+
+func bytesToAddress(bytes []byte) *Address {
+	var addr Address
+	if err := rlp.DecodeBytes(bytes, &addr); err != nil {
+		log.Fatalf("failed to RLP-decode Address: %v", err)
+	}
+	return &addr
+}

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -20,6 +20,16 @@ type Address struct {
 	raftPort uint16
 }
 
+func newAddress(raftId uint16, node *discover.Node) *Address {
+	return &Address{
+		raftId:   raftId,
+		nodeId:   node.ID,
+		ip:       node.IP,
+		p2pPort:  node.TCP,
+		raftPort: raftPort(raftId),
+	}
+}
+
 // A peer that we're connected to via both raft's http transport, and ethereum p2p
 type Peer struct {
 	address *Address

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -32,8 +32,8 @@ func newAddress(raftId uint16, node *discover.Node) *Address {
 
 // A peer that we're connected to via both raft's http transport, and ethereum p2p
 type Peer struct {
-	address *Address
-	p2pNode *discover.Node
+	address *Address       // For raft transport
+	p2pNode *discover.Node // For ethereum transport
 }
 
 func (addr *Address) EncodeRLP(w io.Writer) error {

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -20,13 +20,13 @@ type Address struct {
 	raftPort uint16
 }
 
-func newAddress(raftId uint16, node *discover.Node) *Address {
+func newAddress(raftId uint16, raftPort uint16, node *discover.Node) *Address {
 	return &Address{
 		raftId:   raftId,
 		nodeId:   node.ID,
 		ip:       node.IP,
 		p2pPort:  node.TCP,
-		raftPort: raftPort(raftId),
+		raftPort: raftPort,
 	}
 }
 

--- a/raft/persistence.go
+++ b/raft/persistence.go
@@ -41,13 +41,13 @@ func (pm *ProtocolManager) loadAppliedIndex() uint64 {
 		lastAppliedIndex = binary.LittleEndian.Uint64(dat)
 	}
 
-	glog.V(logger.Info).Infof("Persistent applied index load: %d", lastAppliedIndex)
+	glog.V(logger.Info).Infof("loaded the latest applied index: %d", lastAppliedIndex)
 	pm.appliedIndex = lastAppliedIndex
 	return lastAppliedIndex
 }
 
 func (pm *ProtocolManager) writeAppliedIndex(index uint64) {
-	glog.V(logger.Info).Infof("Persistent applied index write: %d", index)
+	glog.V(logger.Info).Infof("persisted the latest applied index: %d", index)
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, index)
 	pm.quorumRaftDb.Put(appliedDbKey, buf, noFsync)

--- a/raft/persistence.go
+++ b/raft/persistence.go
@@ -41,8 +41,12 @@ func (pm *ProtocolManager) loadAppliedIndex() uint64 {
 		lastAppliedIndex = binary.LittleEndian.Uint64(dat)
 	}
 
-	glog.V(logger.Info).Infof("loaded the latest applied index: %d", lastAppliedIndex)
+	pm.mu.Lock()
 	pm.appliedIndex = lastAppliedIndex
+	pm.mu.Unlock()
+
+	glog.V(logger.Info).Infof("loaded the latest applied index: %d", lastAppliedIndex)
+
 	return lastAppliedIndex
 }
 

--- a/raft/persistence.go
+++ b/raft/persistence.go
@@ -9,18 +9,12 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
-	"strconv"
 )
 
 var (
 	noFsync = &opt.WriteOptions{
 		NoWriteMerge: false,
 		Sync:         false,
-	}
-
-	mustFsync = &opt.WriteOptions{
-		NoWriteMerge: false,
-		Sync:         true,
 	}
 )
 
@@ -57,20 +51,4 @@ func (pm *ProtocolManager) writeAppliedIndex(index uint64) {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, index)
 	pm.quorumRaftDb.Put(appliedDbKey, buf, noFsync)
-}
-
-func (pm *ProtocolManager) loadPeerAddress(raftId uint16) *Address {
-	peerUrlKey := []byte(peerUrlKeyPrefix + strconv.Itoa(int(raftId)))
-	value, err := pm.quorumRaftDb.Get(peerUrlKey, nil)
-	if err != nil {
-		glog.Fatalf("failed to read address for raft peer %d from leveldb: %v", raftId, err)
-	}
-
-	return bytesToAddress(value)
-}
-
-func (pm *ProtocolManager) writePeerAddressBytes(raftId uint16, value []byte) {
-	key := []byte(peerUrlKeyPrefix + strconv.Itoa(int(raftId)))
-
-	pm.quorumRaftDb.Put(key, value, mustFsync)
 }

--- a/raft/persistence.go
+++ b/raft/persistence.go
@@ -9,6 +9,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"strconv"
 )
 
 var (
@@ -58,18 +59,18 @@ func (pm *ProtocolManager) writeAppliedIndex(index uint64) {
 	pm.quorumRaftDb.Put(appliedDbKey, buf, noFsync)
 }
 
-func (pm *ProtocolManager) loadPeerUrl(nodeId uint64) string {
-	peerUrlKey := []byte(peerUrlKeyPrefix + string(nodeId))
+func (pm *ProtocolManager) loadPeerAddress(raftId uint16) *Address {
+	peerUrlKey := []byte(peerUrlKeyPrefix + strconv.Itoa(int(raftId)))
 	value, err := pm.quorumRaftDb.Get(peerUrlKey, nil)
 	if err != nil {
-		glog.Fatalf("failed to read peer url for peer %d from leveldb: %v", nodeId, err)
+		glog.Fatalf("failed to read address for raft peer %d from leveldb: %v", raftId, err)
 	}
-	return string(value)
+
+	return bytesToAddress(value)
 }
 
-func (pm *ProtocolManager) writePeerUrl(nodeId uint64, url string) {
-	key := []byte(peerUrlKeyPrefix + string(nodeId))
-	value := []byte(url)
+func (pm *ProtocolManager) writePeerAddressBytes(raftId uint16, value []byte) {
+	key := []byte(peerUrlKeyPrefix + strconv.Itoa(int(raftId)))
 
 	pm.quorumRaftDb.Put(key, value, mustFsync)
 }

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -10,11 +10,199 @@ import (
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/rlp"
+	"gopkg.in/fatih/set.v0"
+	"io"
+	"log"
 	"math/big"
+	"sort"
 	"time"
 )
 
-func (pm *ProtocolManager) saveSnapshot(snap raftpb.Snapshot) error {
+// Snapshot
+
+type Snapshot struct {
+	addresses      []Address
+	removedRaftIds []uint16 // Raft IDs for permanently removed peers
+	headBlockHash  common.Hash
+}
+
+type ByRaftId []Address
+
+func (a ByRaftId) Len() int           { return len(a) }
+func (a ByRaftId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByRaftId) Less(i, j int) bool { return a[i].raftId < a[j].raftId }
+
+func (pm *ProtocolManager) buildSnapshot(withoutSelf bool) *Snapshot {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	var numNodes int
+	if withoutSelf {
+		numNodes = len(pm.peers)
+	} else {
+		numNodes = len(pm.peers) + 1
+	}
+
+	snapshot := &Snapshot{
+		addresses:     make([]Address, numNodes),
+		headBlockHash: pm.blockchain.CurrentBlock().Hash(),
+	}
+	i := 0
+	for _, peer := range pm.peers {
+		snapshot.addresses[i] = *peer.address
+		i += 1
+	}
+	if !withoutSelf {
+		snapshot.addresses[i] = *pm.address
+	}
+
+	sort.Sort(ByRaftId(snapshot.addresses))
+
+	return snapshot
+}
+
+func (pm *ProtocolManager) triggerSnapshot(withoutSelf bool) {
+	glog.V(logger.Info).Infof("start snapshot [applied index: %d | last snapshot index: %d]", pm.appliedIndex, pm.snapshotIndex)
+
+	snapData := pm.buildSnapshot(withoutSelf).toBytes()
+	snap, err := pm.raftStorage.CreateSnapshot(pm.appliedIndex, &pm.confState, snapData)
+	if err != nil {
+		panic(err)
+	}
+	if err := pm.saveRaftSnapshot(snap); err != nil {
+		panic(err)
+	}
+	// Discard all log entries prior to appliedIndex.
+	if err := pm.raftStorage.Compact(pm.appliedIndex); err != nil {
+		panic(err)
+	}
+	glog.V(logger.Info).Infof("compacted log at index %d", pm.appliedIndex)
+	pm.snapshotIndex = pm.appliedIndex
+}
+
+func confStateIdSet(confState raftpb.ConfState) *set.Set {
+	set := set.New()
+	for _, rawRaftId := range confState.Nodes {
+		set.Add(uint16(rawRaftId))
+	}
+	return set
+}
+
+func (pm *ProtocolManager) updateClusterMembership(newConfState raftpb.ConfState, addresses []Address, removedRaftIds []uint16) {
+	glog.V(logger.Info).Infof("updating cluster membership per raft snapshot")
+
+	prevConfState := pm.confState
+
+	pm.mu.Lock()
+	pm.removedPeers = set.New(removedRaftIds)
+	pm.mu.Unlock()
+
+	prevIds := confStateIdSet(prevConfState)
+	newIds := confStateIdSet(newConfState)
+	idsToRemove := set.Difference(prevIds, newIds)
+	for _, idIfaceToRemove := range idsToRemove.List() {
+		raftId := idIfaceToRemove.(uint16)
+		glog.V(logger.Info).Infof("removing old raft peer %v", raftId)
+
+		pm.removePeer(raftId)
+	}
+
+	for _, address := range addresses {
+		if address.raftId == pm.raftId {
+			pm.mu.Lock()
+			// If we're a newcomer to an existing cluster, this is where we learn
+			// our own Address.
+			pm.address = &address
+			pm.mu.Unlock()
+		} else {
+			pm.mu.RLock()
+			existingPeer := pm.peers[address.raftId]
+			pm.mu.RUnlock()
+
+			if existingPeer == nil {
+				glog.V(logger.Info).Infof("adding new raft peer %v", address.raftId)
+				pm.addPeer(&address)
+			}
+		}
+	}
+
+	pm.mu.Lock()
+	pm.confState = newConfState
+	pm.mu.Unlock()
+
+	glog.V(logger.Info).Infof("updated cluster membership")
+}
+
+// For persisting cluster membership changes correctly, we need to trigger a
+// snapshot before advancing our persisted appliedIndex in LevelDB.
+//
+// See handling of EntryConfChange entries in raft/handler.go for details.
+func (pm *ProtocolManager) triggerSnapshotWithNextIndex(index uint64, withoutSelf bool) {
+	pm.appliedIndex = index
+	pm.triggerSnapshot(withoutSelf)
+}
+
+func (pm *ProtocolManager) maybeTriggerSnapshot() {
+	if pm.appliedIndex-pm.snapshotIndex < snapshotPeriod {
+		return
+	}
+
+	pm.triggerSnapshot(false)
+}
+
+func (pm *ProtocolManager) loadSnapshot() {
+	if raftSnapshot := pm.readRaftSnapshot(); raftSnapshot != nil {
+		glog.V(logger.Info).Infof("loading snapshot")
+
+		pm.applyRaftSnapshot(*raftSnapshot)
+	} else {
+		glog.V(logger.Info).Infof("no snapshot to load")
+	}
+}
+
+func (snapshot *Snapshot) toBytes() []byte {
+	size, r, err := rlp.EncodeToReader(snapshot)
+	if err != nil {
+		panic(fmt.Sprintf("error: failed to RLP-encode Snapshot: %s", err.Error()))
+	}
+	var buffer = make([]byte, uint32(size))
+	r.Read(buffer)
+
+	return buffer
+}
+
+func bytesToSnapshot(bytes []byte) *Snapshot {
+	var snapshot Snapshot
+	if err := rlp.DecodeBytes(bytes, &snapshot); err != nil {
+		log.Fatalf("failed to RLP-decode Snapshot: %v", err)
+	}
+	return &snapshot
+}
+
+func (snapshot *Snapshot) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{snapshot.addresses, snapshot.removedRaftIds, snapshot.headBlockHash})
+}
+
+func (snapshot *Snapshot) DecodeRLP(s *rlp.Stream) error {
+	// These fields need to be public:
+	var temp struct {
+		Addresses      []Address
+		RemovedRaftIds []uint16
+		HeadBlockHash  common.Hash
+	}
+
+	if err := s.Decode(&temp); err != nil {
+		return err
+	} else {
+		snapshot.addresses, snapshot.removedRaftIds, snapshot.headBlockHash = temp.Addresses, temp.RemovedRaftIds, temp.HeadBlockHash
+		return nil
+	}
+}
+
+// Raft snapshot
+
+func (pm *ProtocolManager) saveRaftSnapshot(snap raftpb.Snapshot) error {
 	if err := pm.snapshotter.SaveSnap(snap); err != nil {
 		return err
 	}
@@ -31,42 +219,7 @@ func (pm *ProtocolManager) saveSnapshot(snap raftpb.Snapshot) error {
 	return pm.wal.ReleaseLockTo(snap.Metadata.Index)
 }
 
-func (pm *ProtocolManager) maybeTriggerSnapshot() {
-	if pm.appliedIndex-pm.snapshotIndex < snapshotPeriod {
-		return
-	}
-
-	pm.triggerSnapshot()
-}
-
-func (pm *ProtocolManager) triggerSnapshot() {
-	glog.V(logger.Info).Infof("start snapshot [applied index: %d | last snapshot index: %d]", pm.appliedIndex, pm.snapshotIndex)
-	snapData := pm.blockchain.CurrentBlock().Hash().Bytes()
-	snap, err := pm.raftStorage.CreateSnapshot(pm.appliedIndex, &pm.confState, snapData)
-	if err != nil {
-		panic(err)
-	}
-	if err := pm.saveSnapshot(snap); err != nil {
-		panic(err)
-	}
-	// Discard all log entries prior to appliedIndex.
-	if err := pm.raftStorage.Compact(pm.appliedIndex); err != nil {
-		panic(err)
-	}
-	glog.V(logger.Info).Infof("compacted log at index %d", pm.appliedIndex)
-	pm.snapshotIndex = pm.appliedIndex
-}
-
-// For persisting cluster membership changes correctly, we need to trigger a
-// snapshot before advancing our persisted appliedIndex in LevelDB.
-//
-// See handling of EntryConfChange entries in raft/handler.go for details.
-func (pm *ProtocolManager) triggerSnapshotWithNextIndex(index uint64) {
-	pm.appliedIndex = index
-	pm.triggerSnapshot()
-}
-
-func (pm *ProtocolManager) loadSnapshot() *raftpb.Snapshot {
+func (pm *ProtocolManager) readRaftSnapshot() *raftpb.Snapshot {
 	snapshot, err := pm.snapshotter.Load()
 	if err != nil && err != snap.ErrNoSnapshot {
 		glog.Fatalf("error loading snapshot: %v", err)
@@ -75,50 +228,58 @@ func (pm *ProtocolManager) loadSnapshot() *raftpb.Snapshot {
 	return snapshot
 }
 
-func (pm *ProtocolManager) applySnapshot(snap raftpb.Snapshot) {
+func (pm *ProtocolManager) applyRaftSnapshot(raftSnapshot raftpb.Snapshot) {
 	glog.V(logger.Info).Infof("applying snapshot to raft storage")
-	if err := pm.raftStorage.ApplySnapshot(snap); err != nil {
+	if err := pm.raftStorage.ApplySnapshot(raftSnapshot); err != nil {
 		glog.Fatalln("failed to apply snapshot: ", err)
 	}
+	snapshot := bytesToSnapshot(raftSnapshot.Data)
 
-	latestBlockHash := common.BytesToHash(snap.Data)
+	latestBlockHash := snapshot.headBlockHash
+
+	pm.updateClusterMembership(raftSnapshot.Metadata.ConfState, snapshot.addresses, snapshot.removedRaftIds)
 
 	preSyncHead := pm.blockchain.CurrentBlock()
 
 	glog.V(logger.Info).Infof("before sync, chain head is at block %x", preSyncHead.Hash())
 
 	if latestBlock := pm.blockchain.GetBlockByHash(latestBlockHash); latestBlock == nil {
-	syncing:
-		for {
-			for peerId, peer := range pm.peers {
-				glog.V(logger.Info).Infof("synchronizing with peer %v up to block %x", peerId, latestBlockHash)
-
-				peerId := peer.p2pNode.ID.String()
-				peerIdPrefix := fmt.Sprintf("%x", peer.p2pNode.ID[:8])
-
-				if err := pm.downloader.Synchronise(peerIdPrefix, latestBlockHash, big.NewInt(0), downloader.BoundedFullSync); err != nil {
-					glog.V(logger.Warn).Infof("failed to synchronize with peer %v", peerId)
-
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					break syncing
-				}
-			}
-		}
-
+		pm.syncBlockchainUntil(latestBlockHash)
 		pm.logNewlyAcceptedTransactions(preSyncHead)
 
 		glog.V(logger.Info).Infof("%s: %x\n", chainExtensionMessage, pm.blockchain.CurrentBlock().Hash())
 	} else {
-		glog.V(logger.Info).Infof("already caught up; no need to synchronize")
+		glog.V(logger.Info).Infof("blockchain is caught up; no need to synchronize")
 	}
 
-	snapMeta := snap.Metadata
-
+	snapMeta := raftSnapshot.Metadata
 	pm.confState = snapMeta.ConfState
 	pm.snapshotIndex = snapMeta.Index
 	pm.advanceAppliedIndex(snapMeta.Index)
 }
+
+func (pm *ProtocolManager) syncBlockchainUntil(hash common.Hash) {
+	// We don't need to lock access to pm.peers here; only reads can happen
+	// concurrently with this.
+
+	for {
+		for peerId, peer := range pm.peers {
+			glog.V(logger.Info).Infof("synchronizing with peer %v up to block %x", peerId, hash)
+
+			peerId := peer.p2pNode.ID.String()
+			peerIdPrefix := fmt.Sprintf("%x", peer.p2pNode.ID[:8])
+
+			if err := pm.downloader.Synchronise(peerIdPrefix, hash, big.NewInt(0), downloader.BoundedFullSync); err != nil {
+				glog.V(logger.Warn).Infof("failed to synchronize with peer %v", peerId)
+
+				time.Sleep(500 * time.Millisecond)
+			} else {
+				return
+			}
+		}
+	}
+}
+
 func (pm *ProtocolManager) logNewlyAcceptedTransactions(preSyncHead *types.Block) {
 	newHead := pm.blockchain.CurrentBlock()
 	numBlocks := newHead.NumberU64() - preSyncHead.NumberU64()

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -281,7 +281,6 @@ func (pm *ProtocolManager) applyRaftSnapshot(raftSnapshot raftpb.Snapshot) {
 	pm.mu.Lock()
 	pm.snapshotIndex = snapMeta.Index
 	pm.mu.Unlock()
-	pm.advanceAppliedIndex(snapMeta.Index)
 }
 
 func (pm *ProtocolManager) syncBlockchainUntil(hash common.Hash) {

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -175,13 +175,17 @@ func (pm *ProtocolManager) maybeTriggerSnapshot() {
 	pm.triggerSnapshot(appliedIndex)
 }
 
-func (pm *ProtocolManager) loadSnapshot() {
+func (pm *ProtocolManager) loadSnapshot() *raftpb.Snapshot {
 	if raftSnapshot := pm.readRaftSnapshot(); raftSnapshot != nil {
 		glog.V(logger.Info).Infof("loading snapshot")
 
 		pm.applyRaftSnapshot(*raftSnapshot)
+
+		return raftSnapshot
 	} else {
 		glog.V(logger.Info).Infof("no snapshot to load")
+
+		return nil
 	}
 }
 

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -123,11 +123,9 @@ func (pm *ProtocolManager) updateClusterMembership(newConfState raftpb.ConfState
 
 	for _, address := range addresses {
 		if address.raftId == pm.raftId {
-			pm.mu.Lock()
 			// If we're a newcomer to an existing cluster, this is where we learn
 			// our own Address.
-			pm.address = &address
-			pm.mu.Unlock()
+			pm.setLocalAddress(&address)
 		} else {
 			pm.mu.RLock()
 			existingPeer := pm.peers[address.raftId]

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -87,7 +87,7 @@ func (pm *ProtocolManager) triggerSnapshot(index uint64) {
 	if err := pm.saveRaftSnapshot(snap); err != nil {
 		panic(err)
 	}
-	// Discard all log entries prior to appliedIndex.
+	// Discard all log entries prior to index.
 	if err := pm.raftStorage.Compact(index); err != nil {
 		panic(err)
 	}

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -112,7 +112,8 @@ func (pm *ProtocolManager) updateClusterMembership(newConfState raftpb.ConfState
 
 	prevConfState := pm.confState
 
-	// Update tombstones
+	// Update tombstones for permanently removed peers. For simplicity we do not
+	// allow the re-use of peer IDs once a peer is removed.
 
 	removedPeers := set.New()
 	for _, removedRaftId := range removedRaftIds {

--- a/raft/wal.go
+++ b/raft/wal.go
@@ -3,37 +3,30 @@ package raft
 import (
 	"os"
 
-	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/wal"
 	"github.com/coreos/etcd/wal/walpb"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 )
 
-func (pm *ProtocolManager) openWAL(maybeSnapshot *raftpb.Snapshot) *wal.WAL {
+func (pm *ProtocolManager) openWAL() *wal.WAL {
 	if !wal.Exist(pm.waldir) {
 		if err := os.Mkdir(pm.waldir, 0750); err != nil {
-			glog.Fatalf("cannot create waldir (%v)", err)
+			glog.Fatalf("cannot create waldir: %v", err)
 		}
 
 		wal, err := wal.Create(pm.waldir, nil)
 		if err != nil {
-			glog.Fatalf("failed to create waldir (%v)", err)
+			glog.Fatalf("failed to create waldir: %v", err)
 		}
 		wal.Close()
 	}
 
-	walsnap := walpb.Snapshot{}
-	if maybeSnapshot != nil {
-		walsnap.Index = maybeSnapshot.Metadata.Index
-		walsnap.Term = maybeSnapshot.Metadata.Term
-	}
+	glog.V(logger.Info).Infof("loading WAL")
 
-	glog.V(logger.Info).Infof("loading WAL at term %d and index %d", walsnap.Term, walsnap.Index)
-
-	wal, err := wal.Open(pm.waldir, walsnap)
+	wal, err := wal.Open(pm.waldir, walpb.Snapshot{})
 	if err != nil {
-		glog.Fatalf("error loading WAL (%v)", err)
+		glog.Fatalf("error loading WAL: %v", err)
 	}
 
 	return wal
@@ -41,16 +34,11 @@ func (pm *ProtocolManager) openWAL(maybeSnapshot *raftpb.Snapshot) *wal.WAL {
 
 func (pm *ProtocolManager) replayWAL() *wal.WAL {
 	glog.V(logger.Info).Infoln("replaying WAL")
-	maybeSnapshot := pm.loadSnapshot()
-	wal := pm.openWAL(maybeSnapshot)
+	wal := pm.openWAL()
 
 	_, hardState, entries, err := wal.ReadAll()
 	if err != nil {
-		glog.Fatalf("failed to read WAL (%v)", err)
-	}
-
-	if maybeSnapshot != nil {
-		pm.applySnapshot(*maybeSnapshot)
+		glog.Fatalf("failed to read WAL: %v", err)
 	}
 
 	pm.raftStorage.SetHardState(hardState)


### PR DESCRIPTION
This adds support for dynamic membership support (i.e. adding and removing nodes after initial cluster creation) for Raft-based consensus.

Summary of changes:

- Geth clients can now add new peers with `raft.addPeer(enodeId)` and remove existing peers with `raft.removePeer(raftId)`, where `raftId` is the number allocated/returned from `addPeer` (for newcomers to the cluster), or the 1-indexed position of an initial cluster member in the static peers list. Removal from the cluster is permanent, and if a party wishes to re-join the cluster after removal, they must be re-added. If a new node is added after the cluster has already started, they join with `--raftjoinexisting id`
- Added downloader support for a new `BoundedFullSync` mode, by which one node "fully" synchronizes with another, but only up to a specified block. Dynamically added peers, and peers that have fallen behind (e.g. after a crash), now use this functionality to catch their blockchain up with the rest of the cluster on start-up.
- All cluster information (i.e. `Address`es, to connect to other nodes, and "removed raft IDs") is now stored in raft snapshots (rather than LevelDB) so newcomers to the cluster can join without having to know all peer addresses a priori -- the rest of the cluster will connect to the newcomer.
- Added logic to recover from an etcd/raft corner case after a node crash (see coreos/etcd#7899)
- Updated documentation to reflect dynamic membership support
- Nodes can specify a custom raft port with `--raftport 12345`. If this option is omitted, we default to port 50400.

/cc @joelburget @jpmsam @patrickmn @tylobban