### PR TITLE
[WIP] Implement private tx support for ethclient and abigen

### DIFF
--- a/accounts/abi/bind/backend.go
+++ b/accounts/abi/bind/backend.go
@@ -88,6 +88,10 @@ type ContractTransactor interface {
 	EstimateGas(ctx context.Context, call ethereum.CallMsg) (usedGas *big.Int, err error)
 	// SendTransaction injects the transaction into the pending pool for execution.
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
+	// PreparePrivateTransaction sends the encoded raw transaction to Constellation,
+	// returning the encoded commitment transaction.
+	PreparePrivateTransaction(ctx context.Context, tx *types.Transaction,
+		privateFrom []byte, privateFor [][]byte) (*types.Transaction, error)
 }
 
 // ContractBackend defines the methods needed to work with contracts on a read-write basis.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -180,7 +180,11 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) Data() []byte { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) SetData(data []byte) {
+	tx.data.Payload = common.CopyBytes(data)
+}
+
 func (tx *Transaction) Gas() *big.Int      { return new(big.Int).Set(tx.data.GasLimit) }
 func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }
 func (tx *Transaction) Value() *big.Int    { return new(big.Int).Set(tx.data.Amount) }

--- a/eth/bind.go
+++ b/eth/bind.go
@@ -136,3 +136,22 @@ func (b *ContractBackend) SendTransaction(ctx context.Context, tx *types.Transac
 	_, err := b.txapi.SendRawTransaction(ctx, raw)
 	return err
 }
+
+// PreparePrivateTransaction replaces the payload data of the transaction with a
+// commitment to turn it into a private tx.
+func (b *ContractBackend) PreparePrivateTransaction(ctx context.Context, tx *types.Transaction, privateFrom []byte, privateFor [][]byte) (*types.Transaction, error) {
+	raw, _ := rlp.EncodeToBytes(tx)
+
+	privateInfo := ethapi.NewPrivateTxInfoBinary(privateFrom, privateFor)
+	privTxBytes, err := b.txapi.PreparePrivateTransaction(ctx, raw, privateInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	tx = new(types.Transaction)
+	if err := rlp.DecodeBytes(privTxBytes, tx); err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}


### PR DESCRIPTION
It's really non-trivial to figure out where in the code the private parts of the transaction are handled.

Looking at `SendTransaction`, it does two things with the private stuff:
- call `private.P.Send()` with the tx data from the call, and afterwards use the newly returned data instead of the original one
- calling `SetPrivate()` on the transaction before handing it to `Backend.SendTx()`

The second one I can do, without a problem. The first one, though, is not easy. What I suppose I have to do is to send `tx.Data()` and then somehow replace that data with the new data. This would mean that I'd have to create a new `types.Transaction` object because you can't alter the private `txdata` field. I could in theory do that, but I guess that would invalidate the signature, no?


Involves #90 and #112.


