### PR TITLE
private: Distinguish between privateFor being absent vs. an empty array to allow self-sending

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -277,7 +277,7 @@ func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs
 
 	var tx *types.Transaction
 	data := common.FromHex(args.Data)
-	isPrivate := len(args.PrivateFor) > 0
+	isPrivate := args.PrivateFor != nil
 	if isPrivate {
 		data, err = private.P.Send(data, args.PrivateFrom, args.PrivateFor)
 		if err != nil {
@@ -377,7 +377,7 @@ func (a *Async) save(ctx context.Context, s *PublicTransactionPoolAPI, args Send
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return submitTransaction(ctx, s.b, tx, signature, len(args.PrivateFor) > 0)
+	return submitTransaction(ctx, s.b, tx, signature, args.PrivateFor != nil)
 }
 
 func newAsync(n int) *Async {
@@ -1221,7 +1221,7 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 
 	var tx *types.Transaction
 	data := common.FromHex(args.Data)
-	isPrivate := len(args.PrivateFor) > 0
+	isPrivate := args.PrivateFor != nil
 	if isPrivate {
 		data, err = private.P.Send(data, args.PrivateFrom, args.PrivateFor)
 		if err != nil {

--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -6,28 +6,15 @@ import (
 	"time"
 )
 
-func copyBytes(b []byte) []byte {
-	ob := make([]byte, len(b))
-	copy(ob, b)
-	return ob
-}
-
 type Constellation struct {
 	node *Client
 	c    *cache.Cache
 }
 
 func (g *Constellation) Send(data []byte, from string, to []string) (out []byte, err error) {
-	if len(data) > 0 {
-		if len(to) == 0 {
-			out = copyBytes(data)
-		} else {
-			var err error
-			out, err = g.node.SendPayload(data, from, to)
-			if err != nil {
-				return nil, err
-			}
-		}
+	out, err = g.node.SendPayload(data, from, to)
+	if err != nil {
+		return nil, err
 	}
 	g.c.Set(string(out), data, cache.DefaultExpiration)
 	return out, nil


### PR DESCRIPTION
Previously the absence of privateFor and `privateFor: []` meant the same thing: that the transaction is not private. Now, the latter will indicate that the transaction is private, but that it is applied only by the sender.

Fixes https://github.com/jpmorganchase/quorum/issues/81
Related Constellation modification: https://github.com/jpmorganchase/constellation/pull/49