### PR TITLE
Remove Quorum version insertion.

### DIFF
--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -112,6 +112,7 @@ func version(ctx *cli.Context) error {
 	if gitCommit != "" {
 		fmt.Println("Git Commit:", gitCommit)
 	}
+	fmt.Println("Quorum Version:", params.QuorumVersion)
 	fmt.Println("Architecture:", runtime.GOARCH)
 	fmt.Println("Network Id:", eth.DefaultConfig.NetworkId)
 	fmt.Println("Go Version:", runtime.Version())

--- a/params/version.go
+++ b/params/version.go
@@ -38,9 +38,12 @@ var Version = func() string {
 		v += "-" + VersionMeta
 	}
 
-	v = fmt.Sprintf("quorum %d.%d.%d (geth %s)", QuorumVersionMajor, QuorumVersionMinor, QuorumVersionPatch, v)
-
 	return v
+}()
+
+// Version holds the textual version string.
+var QuorumVersion = func() string {
+	return fmt.Sprintf("%d.%d.%d", QuorumVersionMajor, QuorumVersionMinor, QuorumVersionPatch)
 }()
 
 func VersionWithCommit(gitCommit string) string {


### PR DESCRIPTION
It results in "Geth/vquorum" in the console.