### PR TITLE
Allow running geth with IsQuorum disabled

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -191,8 +191,6 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 	// config is supplied. These chains would get AllProtocolChanges (and a compat error)
 	// if we just continued here.
 	if genesis == nil && stored != params.MainnetGenesisHash {
-		log.Info("Reconfiguring old genesis as Quorum")
-		storedcfg.IsQuorum = true
 		return storedcfg, stored, nil
 	}
 


### PR DESCRIPTION
Opening this PR for discussion -- not necessarily to merge this commit.

At the moment it seems that it's not possible to run Quorum with the `IsQuorum` configuration option disabled. If I set `config.isQuorum` to `false` in `genesis.json`, the following line overwrites it and forces it to `True`:

https://github.com/jpmorganchase/quorum/blob/0905eda48eb07a4ce0e7072c1a2ecbf690ddff77/core/genesis.go#L195

I've been adding support for non-raft consensus mechanisms to quorum-tools, but in order to do so, I've had to run a locally-modified Quorum with [this commit](https://github.com/jpmorganchase/quorum/commit/6920d8ef8698e7a1391ba40e35915abf306dc83a) applied, so that I can successfully run e.g. proof-of-work or clique.

@joelburget was saying that this line was added for upgrade-path reasons. Is it possible that we could respect the `IsQuorum` value as specified by the genesis block, and maybe add a commandline option (e.g. `--quorum` or `--force-quorum`) if people need to override it? Or: what is the upgrade-path requirement here, and is there some other way we can accomplish it?