### PR TITLE
Add an memory based Private Transaction Manager

### DIFF
--- a/private/memory/memory_private_transation_manager.go
+++ b/private/memory/memory_private_transation_manager.go
@@ -1,0 +1,45 @@
+package memory
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+)
+
+// MemoryPrivateTransactionManger implements an in memory representation of the Private Transaction Manager Interface
+type MemoryPrivateTransactionManger struct {
+	privDB map[string][]byte
+}
+
+// Send Sends a payload to list of "to" addresses
+// Implements the PrivateTransactionManager.Send() interface
+// Store payload into local repository, returning key (hash of payload)
+func (g *MemoryPrivateTransactionManger) Send(data []byte, from string, to []string) (out []byte, err error) {
+	h := sha512.New512_256()
+
+	h.Write(data)
+
+	out = h.Sum(nil)
+
+	b64Key := base64.StdEncoding.EncodeToString(out)
+	g.privDB[b64Key] = data
+
+	//Out is hash key for retrieval of the payload
+	return out, nil
+}
+
+// Receive Retrieve Payload for the key (data).
+// Implements the PrivateTransactionManager.Receive() interface
+func (g *MemoryPrivateTransactionManger) Receive(data []byte) ([]byte, error) {
+
+	b64Key := base64.StdEncoding.EncodeToString(data)
+	pl := g.privDB[b64Key]
+
+	return pl, nil
+}
+
+// MustNew Instantiates the in memory database
+func MustNew() *MemoryPrivateTransactionManger {
+	return &MemoryPrivateTransactionManger{
+		privDB: make(map[string][]byte),
+	}
+}

--- a/private/memory/memory_private_transation_manager_test.go
+++ b/private/memory/memory_private_transation_manager_test.go
@@ -1,0 +1,34 @@
+package memory
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSendAndReceive(t *testing.T) {
+	g := MustNew()
+
+	data := []byte{1, 2, 3, 4, 5}
+	to := []string{"A", "B", "C"}
+	from := "sendNode"
+
+	key, _ := g.Send(data, from, to)
+
+	result, _ := g.Receive(key)
+
+	if !bytes.Equal(data, result) {
+		t.Errorf("Expected % x got % x", data, result)
+	}
+}
+
+func TestReceiveWithoutSend(t *testing.T) {
+	g := MustNew()
+
+	key := []byte{1, 2}
+
+	result, _ := g.Receive(key)
+
+	if !bytes.Equal(nil, result) {
+		t.Errorf("Expected nil got % x", result)
+	}
+}


### PR DESCRIPTION
Stubbed out Constellation by creating a simple in memory based Private Transaction Manager.

