### PR TITLE
Fixed missing DataDir value in p2p server that affected permissioned nodes

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -156,6 +156,7 @@ func (n *Node) Start() error {
 		n.serverConfig.NodeDatabase = n.config.NodeDB()
 	}
 	n.serverConfig.EnableNodePermission = n.config.EnableNodePermission
+	n.serverConfig.DataDir = n.config.DataDir
 	running := &p2p.Server{Config: n.serverConfig}
 	log.Info("Starting peer-to-peer node", "instance", n.serverConfig.Name)
 


### PR DESCRIPTION
the p2p layer uses a different config object that contains the DataDir, which the permissioned nodes logic uses to find the permissioned-nodes.json file. That value needs to be sync'ed to the node's config object's DataDir collected from geth parameters.