### PR TITLE
Fix sometimes printing wrong address.

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -39,6 +39,7 @@ var (
 
 // deriveSigner makes a *best* guess about which signer to use.
 func deriveSigner(V *big.Int) Signer {
+	// joel: this is one of the two places we used a wrong signer to print txes
 	if V.Sign() != 0 && isProtectedV(V) {
 		return NewEIP155Signer(deriveChainId(V))
 	} else {
@@ -131,7 +132,10 @@ func (tx *Transaction) Protected() bool {
 func isProtectedV(V *big.Int) bool {
 	if V.BitLen() <= 8 {
 		v := V.Uint64()
-		return v != 27 && v != 28
+		// 27 / 28 are pre eip 155 -- ie unprotected.
+		// TODO(joel): this is a hack. Everywhere else we maintain vanilla ethereum
+		// compatibility and we should figure out how to extend that to here
+		return !(v == 27 || v == 28 || v == 37 || v == 38)
 	}
 	// anything not 27 or 28 are considered unprotected
 	return true

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -834,6 +834,7 @@ type RPCTransaction struct {
 // representation, with the given location metadata set (if available).
 func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) *RPCTransaction {
 	var signer types.Signer = types.HomesteadSigner{}
+	// joel: this is one of the two places we used a wrong signer to print txes
 	if tx.Protected() {
 		signer = types.NewEIP155Signer(tx.ChainId())
 	}


### PR DESCRIPTION
Prior to this fix, a series of submitted transactions in the javascript
console would each show a different "from" field when inspected with
`eth.getTransaction`.

It turns out the transactions were all created with the correct sender,
but were just printed incorrectly. We were using the EIP155Signer when
all Quorum transactions expect the HomesteadSigner.

This fix is not exactly satisfying, since in every other place we've
been able to use an `isQuorum` boolean to tell whether a `v` of `37` or
`38` denotes a quorum private tx, but it's particularly hard to do that
in these two places.