### PR TITLE
Disable ethash by replacing with ethash.NewFullFake

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -235,23 +235,23 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 	}
 
 	// Otherwise assume proof-of-work
-  switch {
-  case config.PowFake:
-          log.Warn("Ethash used in fake mode")
-          return ethash.NewFaker()
-  case config.PowTest:
-          log.Warn("Ethash used in test mode")
-          return ethash.NewTester()
-  case config.PowShared:
-          log.Warn("Ethash used in shared mode")
-          return ethash.NewShared()
-  default:
-          // For Quorum, Raft run as a separate service, so
-          // the Ethereum service still needs a consensus engine,
-          // use the consensus with the lightest overhead
-          log.Warn("Ethash used in full fake mode")
-          return ethash.NewFullFaker()
-  }
+	switch {
+	case config.PowFake:
+		log.Warn("Ethash used in fake mode")
+		return ethash.NewFaker()
+	case config.PowTest:
+		log.Warn("Ethash used in test mode")
+		return ethash.NewTester()
+	case config.PowShared:
+		log.Warn("Ethash used in shared mode")
+		return ethash.NewShared()
+	default:
+		// For Quorum, Raft run as a separate service, so
+		// the Ethereum service still needs a consensus engine,
+		// use the consensus with the lightest overhead
+		log.Warn("Ethash used in full fake mode")
+		return ethash.NewFullFaker()
+	}
 }
 
 // APIs returns the collection of RPC services the ethereum package offers.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -235,11 +235,23 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 	}
 
 	// Otherwise assume proof-of-work
-	// For Quorum, Raft run as a separate service, so
-	// the Ethereum service still needs a consensus engine,
-	// use the consensus with the lightest overhead
-	log.Warn("Ethash used in full fake mode")
-	return ethash.NewFullFaker()
+  switch {
+  case config.PowFake:
+          log.Warn("Ethash used in fake mode")
+          return ethash.NewFaker()
+  case config.PowTest:
+          log.Warn("Ethash used in test mode")
+          return ethash.NewTester()
+  case config.PowShared:
+          log.Warn("Ethash used in shared mode")
+          return ethash.NewShared()
+  default:
+          // For Quorum, Raft run as a separate service, so
+          // the Ethereum service still needs a consensus engine,
+          // use the consensus with the lightest overhead
+          log.Warn("Ethash used in full fake mode")
+          return ethash.NewFullFaker()
+  }
 }
 
 // APIs returns the collection of RPC services the ethereum package offers.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -235,22 +235,11 @@ func CreateConsensusEngine(ctx *node.ServiceContext, config *Config, chainConfig
 	}
 
 	// Otherwise assume proof-of-work
-	switch {
-	case config.PowFake:
-		log.Warn("Ethash used in fake mode")
-		return ethash.NewFaker()
-	case config.PowTest:
-		log.Warn("Ethash used in test mode")
-		return ethash.NewTester()
-	case config.PowShared:
-		log.Warn("Ethash used in shared mode")
-		return ethash.NewShared()
-	default:
-		engine := ethash.New(ctx.ResolvePath(config.EthashCacheDir), config.EthashCachesInMem, config.EthashCachesOnDisk,
-			config.EthashDatasetDir, config.EthashDatasetsInMem, config.EthashDatasetsOnDisk)
-		engine.SetThreads(-1) // Disable CPU mining
-		return engine
-	}
+	// For Quorum, Raft run as a separate service, so
+	// the Ethereum service still needs a consensus engine,
+	// use the consensus with the lightest overhead
+	log.Warn("Ethash used in full fake mode")
+	return ethash.NewFullFaker()
 }
 
 // APIs returns the collection of RPC services the ethereum package offers.


### PR DESCRIPTION
Given that the Raft consensus is implemented as a Service rather than a consensus engine, it essentially runs alongside ethhash. Most of the time the fact that ethash is "active" is not an issue, but in some circumstances this can have negative impact on the Geth node's availability. What we have observed is that when the memory allocated to the Geth process is low, generating and regenerating the ethash verification cache can take a long time (several minutes) and as this is happening the node is not able to commit blocks.

This PR is an attempt to disable ethash. I found using Geth's built-in "faked pow" works pretty well. But surely more testing could be done to ensure this doesn't impact how Raft behaves. Note that this change does not impact IBFT.