### PR TITLE
Quorum Blockchain Explorer is not open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Further documentation can be found in the [docs](docs/) folder and on the [wiki]
 
 The following Quorum-related libraries/applications have been created by Third Parties and as such are not specifically endorsed by J.P. Morgan.  A big thanks to the developers for improving the tooling around Quorum!
 
-* [Quorum Blockchain Explorer](https://github.com/blk-io/blk-explorer-free) - a Blockchain Explorer for Quorum which supports viewing private transactions
+* [Quorum Blockchain Explorer](https://github.com/blk-io/blk-explorer-free) - a Blockchain Explorer for Quorum which supports viewing private transactions (not open source)
 * [Quorum-Genesis](https://github.com/davebryson/quorum-genesis) - A simple CL utility for Quorum to help populate the genesis file with voters and makers
 * [Quorum Maker](https://github.com/synechron-finlabs/quorum-maker/tree/development) - a utility to create Quorum nodes
 * [QuorumNetworkManager](https://github.com/ConsenSys/QuorumNetworkManager) - makes creating & managing Quorum networks easy


### PR DESCRIPTION
Quorum Blockchain Explorer is not open source, that is against expectations from a project on GitHub

ref https://github.com/blk-io/blk-explorer-free/issues/5