### PR TITLE
Use eip155 signer for public transactions

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -278,7 +278,7 @@ func (ks *KeyStore) SignTx(a accounts.Account, tx *types.Transaction, chainID *b
 		return nil, ErrLocked
 	}
 	// Depending on the presence of the chain ID, sign with EIP155 or homestead
-	if chainID != nil && !isQuorum {
+	if chainID != nil && !tx.IsPrivate() {
 		return types.SignTx(tx, types.NewEIP155Signer(chainID), unlockedKey.PrivateKey)
 	}
 	return types.SignTx(tx, types.HomesteadSigner{}, unlockedKey.PrivateKey)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -133,9 +133,7 @@ func isProtectedV(V *big.Int) bool {
 	if V.BitLen() <= 8 {
 		v := V.Uint64()
 		// 27 / 28 are pre eip 155 -- ie unprotected.
-		// TODO(joel): this is a hack. Everywhere else we maintain vanilla ethereum
-		// compatibility and we should figure out how to extend that to here
-		return !(v == 27 || v == 28 || v == 37 || v == 38)
+		return !(v == 27 || v == 28)
 	}
 	// anything not 27 or 28 are considered unprotected
 	return true

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1169,10 +1169,9 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 	tx := args.toTransaction()
 
 	var chainID *big.Int
-	isQuorum := false
+	isQuorum := tx.IsPrivate()
 	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) && !isPrivate {
 		chainID = config.ChainId
-		isQuorum = true
 	}
 	signed, err := wallet.SignTx(account, tx, chainID, isQuorum)
 	if err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1052,10 +1052,9 @@ func (s *PublicTransactionPoolAPI) sign(addr common.Address, tx *types.Transacti
 	}
 	// Request the wallet to sign the transaction
 	var chainID *big.Int
-	isQuorum := false
+	isQuorum := tx.IsPrivate()
 	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) && !tx.IsPrivate() {
 		chainID = config.ChainId
-		isQuorum = true
 	}
 	return wallet.SignTx(account, tx, chainID, isQuorum)
 }


### PR DESCRIPTION
Use eip155 for public transactions. Private transactions will continue to use V={37,38}, hence you need to set chain id to some value other than 1 to avoid conflict. This PR should be merged along with #350 (which enable eip155 for locally signed transactions), and #354 (which fixes `TestEIP155SigningVitalik` by using a new set of test vectors with `chain_id=10`)

Tested on public value transfer, private contract deployment, public contract deployment on 'Ubuntu 16.04.4 LTS` with `Web3 1.0.0-beta.34` and `chain_id=10`.