### PR TITLE
Use permissioned-nodes.json for discovery

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -96,12 +96,14 @@ func main() {
 		}
 	}
 
+	var knownNodes []*discover.Node
+
 	if *runv5 {
 		if _, err := discv5.ListenUDP(nodeKey, *listenAddr, natm, "", restrictList); err != nil {
 			utils.Fatalf("%v", err)
 		}
 	} else {
-		if _, err := discover.ListenUDP(nodeKey, *listenAddr, natm, "", restrictList); err != nil {
+		if _, err := discover.ListenUDP(nodeKey, *listenAddr, natm, "", restrictList, knownNodes); err != nil {
 			utils.Fatalf("%v", err)
 		}
 	}

--- a/p2p/discover/udp_test.go
+++ b/p2p/discover/udp_test.go
@@ -60,6 +60,7 @@ type udpTest struct {
 	sent                [][]byte
 	localkey, remotekey *ecdsa.PrivateKey
 	remoteaddr          *net.UDPAddr
+	knownNodes          []*Node
 }
 
 func newUDPTest(t *testing.T) *udpTest {
@@ -70,7 +71,7 @@ func newUDPTest(t *testing.T) *udpTest {
 		remotekey:  newkey(),
 		remoteaddr: &net.UDPAddr{IP: net.IP{10, 0, 1, 99}, Port: 30303},
 	}
-	test.table, test.udp, _ = newUDP(test.localkey, test.pipe, nil, "", nil)
+	test.table, test.udp, _ = newUDP(test.localkey, test.pipe, nil, "", nil, test.knownNodes)
 	return test
 }
 


### PR DESCRIPTION
If discovery is enabled, use the permissioned nodes list to pre-populate the node database.

Discovery needs to be enabled for this to work, but I think, in theory, you could disable the UDP port at the firewall and still get the benefits of this.  Ideally, it would be nice to be able to decouple the mechanism for finding new nodes to talk to from the UDP gossip implementations.

Fixes #287


