### PR TITLE
Fix TestChainTxReorgs

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -753,7 +753,7 @@ func TestChainTxReorgs(t *testing.T) {
 		db, _   = ethdb.NewMemDatabase()
 		gspec   = &Genesis{
 			Config:   params.TestChainConfig,
-			GasLimit: 3141592,
+			GasLimit: 700000000,
 			Alloc: GenesisAlloc{
 				addr1: {Balance: big.NewInt(1000000)},
 				addr2: {Balance: big.NewInt(1000000)},


### PR DESCRIPTION
Fix to `TestChainTxReorgs` at `/core/blockchain_test.go`

Minimum gas limit is increased by this commit https://github.com/jpmorganchase/quorum/commit/d78cd97995f824239463717d3a0bbbb060e36643, hence gas limit of genesis must be increased at testing.

It was failing at this line of code. https://github.com/jpmorganchase/quorum/blob/master/consensus/ethash/consensus.go#L290