### PR TITLE
Raft Block Signature

### DIFF
--- a/raft/backend.go
+++ b/raft/backend.go
@@ -3,6 +3,7 @@ package raft
 import (
 	"sync"
 	"time"
+	"crypto/ecdsa"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/core"
@@ -32,6 +33,7 @@ type RaftService struct {
 	// we need an event mux to instantiate the blockchain
 	eventMux *event.TypeMux
 	minter   *minter
+	nodeKey  *ecdsa.PrivateKey
 }
 
 func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftId, raftPort uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*discover.Node, datadir string) (*RaftService, error) {
@@ -43,6 +45,7 @@ func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftId, raft
 		accountManager: e.AccountManager(),
 		downloader:     e.Downloader(),
 		startPeers:     startPeers,
+		nodeKey:        ctx.NodeKey(),
 	}
 
 	service.minter = newMinter(chainConfig, service, blockTime)

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -438,7 +438,7 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 
 	var extra *extraSeal
 	extra = &extraSeal{
-		RaftId: []byte(raftIdString),
+		RaftId: []byte(raftIdString[2:]), //remove the 0x prefix
 		Signature: sig,
 	}
 

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -51,7 +50,7 @@ type minter struct {
 	config           *params.ChainConfig
 	mu               sync.Mutex
 	mux              *event.TypeMux
-	eth              miner.Backend
+	eth              *RaftService
 	chain            *core.BlockChain
 	chainDb          ethdb.Database
 	coinbase         common.Address

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"strconv"
 
 	"github.com/eapache/channels"
 	"github.com/ethereum/go-ethereum/common"
@@ -37,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var (
@@ -73,8 +73,8 @@ type minter struct {
 }
 
 type extraSeal struct {
-	raftId    []byte  // RaftID of the block minter
-	signature []byte  // Signature of the block minter
+	RaftId    []byte  // RaftID of the block minter
+	Signature []byte  // Signature of the block minter
 }
 
 func newMinter(config *params.ChainConfig, eth *RaftService, blockTime time.Duration) *minter {
@@ -434,11 +434,16 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 	}
 
 	//build the extraSeal struct
-	raftIdString := strconv.FormatInt(int64(minter.eth.raftProtocolManager.raftId), 16)
-	extra := &extraSeal{
-		raftId: []byte(raftIdString),
-		signature: sig,
+	raftIdString := hexutil.EncodeUint64(uint64(minter.eth.raftProtocolManager.raftId))
+
+	var extra *extraSeal
+	extra = &extraSeal{
+		RaftId: []byte(raftIdString),
+		Signature: sig,
 	}
+	print("\n")
+	fmt.Printf("%v\n", extra)
+	print("\n")
 
 	//encode to byte array for storage
 	extraDataBytes, err := rlp.EncodeToBytes(&extra)

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -73,7 +73,7 @@ type minter struct {
 }
 
 type extraSeal struct {
-	raftId    string  // RaftID of the block minter
+	raftId    []byte  // RaftID of the block minter
 	signature []byte  // Signature of the block minter
 }
 
@@ -436,12 +436,15 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 	//build the extraSeal struct
 	raftIdString := strconv.FormatInt(int64(minter.eth.raftProtocolManager.raftId), 16)
 	extra := &extraSeal{
-		raftId: raftIdString,
+		raftId: []byte(raftIdString),
 		signature: sig,
 	}
 
 	//encode to byte array for storage
-	extraDataBytes, err := rlp.EncodeToBytes(*extra)
+	extraDataBytes, err := rlp.EncodeToBytes(&extra)
+	print("extraDataBytes: ")
+	print(extraDataBytes)
+	print("\n")
 	if err != nil {
 		log.Warn("Header.Extra Data Encoding failed", "err", err)
 	}

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -330,6 +330,7 @@ func (minter *minter) mintNewBlock() {
 
 	//add signature to header.Extra field
 	sig := minter.signHeader(headerHash)
+	header.Extra = make([]byte, len(sig))
 	copy(header.Extra, sig)
 
 	block := types.NewBlock(header, committedTxes, nil, publicReceipts)

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -25,22 +25,22 @@ import (
 
 	"github.com/eapache/channels"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 var (
-	extraVanity = 32      // Fixed number of extra-data prefix bytes reserved for arbitrary signer vanity
+	extraVanity = 32 // Fixed number of extra-data prefix bytes reserved for arbitrary signer vanity
 )
 
 // Current state information for building the next block
@@ -73,8 +73,8 @@ type minter struct {
 }
 
 type extraSeal struct {
-	RaftId    []byte  // RaftID of the block minter
-	Signature []byte  // Signature of the block minter
+	RaftId    []byte // RaftID of the block minter
+	Signature []byte // Signature of the block minter
 }
 
 func newMinter(config *params.ChainConfig, eth *RaftService, blockTime time.Duration) *minter {
@@ -438,7 +438,7 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 
 	var extra *extraSeal
 	extra = &extraSeal{
-		RaftId: []byte(raftIdString[2:]), //remove the 0x prefix
+		RaftId:    []byte(raftIdString[2:]), //remove the 0x prefix
 		Signature: sig,
 	}
 

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/jpmorganchase/quorum/crypto"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 // Current state information for building the next block

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -436,14 +436,14 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 	//build the extraSeal struct
 	raftIdString := hexutil.EncodeUint64(uint64(minter.eth.raftProtocolManager.raftId))
 
-	var extra *extraSeal
-	extra = &extraSeal{
+	var extra extraSeal
+	extra = extraSeal{
 		RaftId:    []byte(raftIdString[2:]), //remove the 0x prefix
 		Signature: sig,
 	}
 
 	//encode to byte array for storage
-	extraDataBytes, err := rlp.EncodeToBytes(&extra)
+	extraDataBytes, err := rlp.EncodeToBytes(extra)
 	if err != nil {
 		log.Warn("Header.Extra Data Encoding failed", "err", err)
 	}

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -441,15 +441,9 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 		RaftId: []byte(raftIdString),
 		Signature: sig,
 	}
-	print("\n")
-	fmt.Printf("%v\n", extra)
-	print("\n")
 
 	//encode to byte array for storage
 	extraDataBytes, err := rlp.EncodeToBytes(&extra)
-	print("extraDataBytes: ")
-	print(extraDataBytes)
-	print("\n")
 	if err != nil {
 		log.Warn("Header.Extra Data Encoding failed", "err", err)
 	}

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/jpmorganchase/quorum/crypto"
 )
 
 // Current state information for building the next block
@@ -329,6 +330,16 @@ func (minter *minter) mintNewBlock() {
 	for _, l := range logs {
 		l.BlockHash = headerHash
 	}
+
+	//Sign the block
+	nodeKey := minter.eth.nodeKey
+	sig, err := crypto.Sign(headerHash.Bytes(), nodeKey)
+	if err != nil {
+		log.Warn("Block sealing failed", "err", err)
+	}
+
+	//add signature to header.Extra field
+	copy(header.Extra, sig)
 
 	block := types.NewBlock(header, committedTxes, nil, publicReceipts)
 

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rlp"
+	"fmt"
 )
 
 func TestSignHeader(t *testing.T){
@@ -39,11 +40,25 @@ func TestSignHeader(t *testing.T){
 
 	headerHash := header.Hash()
 	extraDataBytes := minter.buildExtraSeal(headerHash)
+	print(extraDataBytes)
 	seal := new(extraSeal)
-	rlp.DecodeBytes(extraDataBytes, *seal)
+	err := rlp.DecodeBytes(extraDataBytes, seal)
+	if err != nil {
+		t.Fatalf("Unable to decode seal: %s", err.Error())
+	}
+	print("\n")
+	fmt.Printf("%v\n", seal)
+	print("\n")
+	print(seal.raftId)
+	print("\n")
+	print(seal.signature)
+	print("\n")
 
 	// Check raftId
-	sealRaftId, _ := strconv.ParseInt(seal.raftId, 16, 64)
+	sealRaftId, err := strconv.ParseInt(string(seal.raftId), 16, 64)
+	if err != nil {
+		t.Errorf("Unable to get RaftId")
+	}
 	if  sealRaftId != int64	(testRaftId) {
 		t.Errorf("RaftID does not match. Expected: %d, Actual: %d", testRaftId, sealRaftId)
 	}
@@ -52,7 +67,7 @@ func TestSignHeader(t *testing.T){
 	sig:= seal.signature
 	pubKey, err := crypto.SigToPub(headerHash.Bytes(), sig)
 	if err != nil {
-		t.Errorf("Unable to get public key from signature: %s", err.Error())
+		t.Fatalf("Unable to get public key from signature: %s", err.Error())
 	}
 
 	//Compare derived public key to original public key

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -1,0 +1,49 @@
+package raft
+
+import (
+	"testing"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/jpmorganchase/quorum/raft/backend"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/node"
+	"math/big"
+	"time"
+)
+
+func TestSignHeader(t *testing.T){
+	//create only what we need to test the signature
+	config := &node.Config{Name: "unit-test", DataDir: ""}
+
+	nodeKey := config.NodeKey()
+	raftService := &RaftService{nodeKey: nodeKey,}
+	minter := minter{eth: raftService,}
+
+	//create some fake header to sign
+	fakeParentHash := common.HexToHash("0xc2c1dc1be8054808c69e06137429899d")
+
+	header := &types.Header{
+		ParentHash: fakeParentHash,
+		Number:     big.NewInt(1),
+		Difficulty: big.NewInt(12),
+		GasLimit:   0,
+		GasUsed:    0,
+		Coinbase:   minter.coinbase,
+		Time:       big.NewInt(time.Now().UnixNano()),
+	}
+
+	sig := minter.signHeader(header.Hash())
+
+	//Identify who signed it
+	pubKey, err := crypto.SigToPub(header.Hash().Bytes(), sig)
+	if err != nil {
+		t.Errorf("Unable to get public key from signature: %s", err.Error())
+	}
+
+	//Compare derived publick key to original public key
+	if pubKey != nodeKey.Public() {
+		t.Errorf("Signature incorrect!")
+	}
+
+}
+

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -32,7 +32,7 @@ func TestSignHeader(t *testing.T){
 	}
 
 	headerHash := header.Hash()
-	sig := minter.signHeader(headerHash)
+	sig := minter.getSignature(headerHash)
 
 	//Identify who signed it
 	pubKey, err := crypto.SigToPub(headerHash.Bytes(), sig)

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -46,7 +46,7 @@ func TestSignHeader(t *testing.T){
 	}
 
 	// Check raftId
-	sealRaftId, err := hexutil.DecodeUint64(string(seal.RaftId))
+	sealRaftId, err := hexutil.DecodeUint64("0x"+ string(seal.RaftId)) //add the 0x prefix
 	if err != nil {
 		t.Errorf("Unable to get RaftId: %s", err.Error())
 	}

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/jpmorganchase/quorum/raft/backend"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
 	"math/big"
@@ -25,25 +24,25 @@ func TestSignHeader(t *testing.T){
 	header := &types.Header{
 		ParentHash: fakeParentHash,
 		Number:     big.NewInt(1),
-		Difficulty: big.NewInt(12),
-		GasLimit:   0,
-		GasUsed:    0,
+		Difficulty: big.NewInt(1),
+		GasLimit:   new(big.Int),
+		GasUsed:    new(big.Int),
 		Coinbase:   minter.coinbase,
 		Time:       big.NewInt(time.Now().UnixNano()),
 	}
 
-	sig := minter.signHeader(header.Hash())
+	headerHash := header.Hash()
+	sig := minter.signHeader(headerHash)
 
 	//Identify who signed it
-	pubKey, err := crypto.SigToPub(header.Hash().Bytes(), sig)
+	pubKey, err := crypto.SigToPub(headerHash.Bytes(), sig)
 	if err != nil {
 		t.Errorf("Unable to get public key from signature: %s", err.Error())
 	}
 
-	//Compare derived publick key to original public key
-	if pubKey != nodeKey.Public() {
+	//Compare derived public key to original public key
+	if pubKey.X.Cmp(nodeKey.X) != 0 {
 		t.Errorf("Signature incorrect!")
 	}
 
 }
-

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"math/big"
 	"time"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -40,22 +39,13 @@ func TestSignHeader(t *testing.T){
 
 	headerHash := header.Hash()
 	extraDataBytes := minter.buildExtraSeal(headerHash)
-	print(extraDataBytes)
 	var seal *extraSeal
 	err := rlp.DecodeBytes(extraDataBytes[:], &seal)
 	if err != nil {
 		t.Fatalf("Unable to decode seal: %s", err.Error())
 	}
-	print("\n")
-	fmt.Printf("%v\n", seal)
-	print("\n")
-	print(seal.RaftId)
-	print("\n")
-	print(seal.Signature)
-	print("\n")
 
 	// Check raftId
-	//sealRaftId, err := strconv.ParseInt(string(seal.raftId), 16, 64)
 	sealRaftId, err := hexutil.DecodeUint64(string(seal.RaftId))
 	if err != nil {
 		t.Errorf("Unable to get RaftId: %s", err.Error())

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -2,16 +2,16 @@ package raft
 
 import (
 	"testing"
-	"strconv"
 	"math/big"
 	"time"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rlp"
-	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func TestSignHeader(t *testing.T){
@@ -41,30 +41,31 @@ func TestSignHeader(t *testing.T){
 	headerHash := header.Hash()
 	extraDataBytes := minter.buildExtraSeal(headerHash)
 	print(extraDataBytes)
-	seal := new(extraSeal)
-	err := rlp.DecodeBytes(extraDataBytes, seal)
+	var seal *extraSeal
+	err := rlp.DecodeBytes(extraDataBytes[:], &seal)
 	if err != nil {
 		t.Fatalf("Unable to decode seal: %s", err.Error())
 	}
 	print("\n")
 	fmt.Printf("%v\n", seal)
 	print("\n")
-	print(seal.raftId)
+	print(seal.RaftId)
 	print("\n")
-	print(seal.signature)
+	print(seal.Signature)
 	print("\n")
 
 	// Check raftId
-	sealRaftId, err := strconv.ParseInt(string(seal.raftId), 16, 64)
+	//sealRaftId, err := strconv.ParseInt(string(seal.raftId), 16, 64)
+	sealRaftId, err := hexutil.DecodeUint64(string(seal.RaftId))
 	if err != nil {
-		t.Errorf("Unable to get RaftId")
+		t.Errorf("Unable to get RaftId: %s", err.Error())
 	}
-	if  sealRaftId != int64	(testRaftId) {
+	if  sealRaftId != uint64(testRaftId) {
 		t.Errorf("RaftID does not match. Expected: %d, Actual: %d", testRaftId, sealRaftId)
 	}
 
 	//Identify who signed it
-	sig:= seal.signature
+	sig:= seal.Signature
 	pubKey, err := crypto.SigToPub(headerHash.Bytes(), sig)
 	if err != nil {
 		t.Fatalf("Unable to get public key from signature: %s", err.Error())


### PR DESCRIPTION
This Pull Request implements block signing for the raft consensus protocol. Currently, any node could cheat by rewriting a block and re-build the chain from that block onward, in its local copy of the chain, and there's no telling that cheating has occurred and which node has the original copy. By implementing block signing, no follower nodes would be able to rewrite the content because they don't have the leader's nodeKey

This is implemented similarly to clique, where a 32-byte vanity and a seal is added to the extraData header field. During block creation, the raft ID of the leader is combined with the leader's signature of the block in a struct, which is then rlp encoded for storage into the extraData field after the vanity.

For the signing to work, the nodeKey needs to be passed further along to the minter. This is possible by adding a nodeKey field to the raftService and changing the backend type of the minter to the more specific raftService struct, similar to clique and IBFT.