### PR TITLE
validate input before calling evm

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -279,6 +279,10 @@ func (st *StateTransition) TransitionDb() (ret []byte, requiredGas, usedGas *big
 		} else {
 			to = st.to().Address()
 		}
+		//if input is empty for the smart contract call, return
+		if len(data) == 0 {
+			return nil, new(big.Int), new(big.Int), false, nil
+		}
 		ret, st.gas, vmerr = evm.Call(sender, to, data, st.gas, st.value)
 	}
 	if vmerr != nil {


### PR DESCRIPTION
This fixes the issue with a node crashing when it is a participant in the private smart contract creation but it is not part of transactions updating the smart contract.