### PR TITLE
Handle explicitly errors spawning from HTTP client interactions

### DIFF
--- a/private/constellation/node.go
+++ b/private/constellation/node.go
@@ -74,7 +74,10 @@ func (c *Client) doJson(path string, apiReq interface{}) (*http.Response, error)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	res, err := c.httpClient.Do(req)
-	if err == nil && res.StatusCode != 200 {
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != 200 {
 		return nil, fmt.Errorf("Non-200 status code: %+v", res)
 	}
 	return res, err
@@ -92,7 +95,10 @@ func (c *Client) SendPayload(pl []byte, b64From string, b64To []string) ([]byte,
 	req.Header.Set("c11n-to", strings.Join(b64To, ","))
 	req.Header.Set("Content-Type", "application/octet-stream")
 	res, err := c.httpClient.Do(req)
-	if err == nil && res.StatusCode != 200 {
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != 200 {
 		return nil, fmt.Errorf("Non-200 status code: %+v", res)
 	}
 	defer res.Body.Close()
@@ -106,7 +112,10 @@ func (c *Client) ReceivePayload(key []byte) ([]byte, error) {
 	}
 	req.Header.Set("c11n-key", base64.StdEncoding.EncodeToString(key))
 	res, err := c.httpClient.Do(req)
-	if err == nil && res.StatusCode != 200 {
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != 200 {
 		return nil, fmt.Errorf("Non-200 status code: %+v", res)
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
This pull request adds code to explicitly handle I/O errors spawn from the HTTP client that interacts with Constellation.


