### PR TITLE
Allow to use http client

### DIFF
--- a/private/constellation/config.go
+++ b/private/constellation/config.go
@@ -7,7 +7,7 @@ import (
 type Config struct {
 	Socket  string `toml:"socket"`
 	WorkDir string `toml:"workdir"`
-
+	BaseURL string `toml:"clienturl"`
 	// Deprecated
 	SocketPath string `toml:"socketPath"`
 }

--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/patrickmn/go-cache"
 	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -48,18 +47,22 @@ func New(path string) (*Constellation, error) {
 	// We accept either the socket or a configuration file that points to
 	// a socket.
 	isSocket := info.Mode() & os.ModeSocket != 0
+	var cfg *Config
 	if !isSocket {
-		cfg, err := LoadConfig(path)
+		cfg, err = LoadConfig(path)
 		if err != nil {
 			return nil, err
 		}
-		path = filepath.Join(cfg.WorkDir, cfg.Socket)
+	} else {
+		cfg = &Config{
+			Socket: path,
+		}
 	}
-	err = RunNode(path)
+	n, err := NewClient(cfg)
 	if err != nil {
 		return nil, err
 	}
-	n, err := NewClient(path)
+	err = UpCheck(n)
 	if err != nil {
 		return nil, err
 	}

--- a/private/constellation/node.go
+++ b/private/constellation/node.go
@@ -47,6 +47,21 @@ func unixClient(socketPath string) *http.Client {
 	}
 }
 
+func httpTransport() *http.Transport {
+	return &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		IdleConnTimeout:     90 * time.Second,
+	}
+}
+
+func httpClient() *http.Client {
+	return &http.Client{
+		Timeout:   time.Second * 5,
+		Transport: httpTransport(),
+	}
+}
+
 func UpCheck(c *Client) error {
 	res, err := c.httpClient.Get(c.BaseURL + "upcheck")
 	if err != nil {
@@ -122,7 +137,7 @@ func NewClient(config *Config) (*Client, error) {
 		client = unixClient(socketPath)
 		baseURL = "http+unix://c/"
 	} else {
-		client = http.DefaultClient
+		client = httpClient()
 		baseURL = config.BaseURL
 		if baseURL[len(baseURL)-1:] != "/" {
 			baseURL += "/"


### PR DESCRIPTION
This PR changes the way Quorum establishes connections to Constellation.

By indicating that the socket configuration parameter is empty or absent, the code uses a HTTP client instead of the Unix domain socket client.

The HTTP client is configured with higher threshold for maximum concurrent connections towards the same host to allow more than the default 2 connections against the same host.

The PR also ensures all responses are fully consumed when sent back so that HTTP connections can be reused. See https://stackoverflow.com/questions/17948827/reusing-http-connections-in-golang#17953506

