### PR TITLE
Feature/300/allow ignore private transaction

### DIFF
--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -1,19 +1,31 @@
 package constellation
 
 import (
+	"errors"
 	"fmt"
-	"github.com/patrickmn/go-cache"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/patrickmn/go-cache"
 )
 
 type Constellation struct {
-	node *Client
-	c    *cache.Cache
+	node   *Client
+	c      *cache.Cache
+	ignore bool
 }
 
+var (
+	ErrConstellationIsntInit = errors.New("ignoreConstellation")
+)
+
 func (g *Constellation) Send(data []byte, from string, to []string) (out []byte, err error) {
+	if g.ignore {
+		return nil, ErrConstellationIsntInit
+	}
 	out, err = g.node.SendPayload(data, from, to)
 	if err != nil {
 		return nil, err
@@ -23,7 +35,12 @@ func (g *Constellation) Send(data []byte, from string, to []string) (out []byte,
 }
 
 func (g *Constellation) Receive(data []byte) ([]byte, error) {
+	if g.ignore {
+		log.Trace("should ignore", "data", fmt.Sprintf("%v", data))
+		return nil, nil
+	}
 	if len(data) == 0 {
+		log.Trace("data has no length", "data", fmt.Sprintf("%v", data))
 		return data, nil
 	}
 	// Ignore this error since not being a recipient of
@@ -31,12 +48,15 @@ func (g *Constellation) Receive(data []byte) ([]byte, error) {
 	// TODO: Return an error if it's anything OTHER than
 	// 'you are not a recipient.'
 	dataStr := string(data)
+	log.Trace("data being processed", "datastring", fmt.Sprintf("%v", dataStr))
+	log.Trace("data being processed", "datastring", fmt.Sprintf("%v", data))
 	x, found := g.c.Get(dataStr)
 	if found {
 		return x.([]byte), nil
 	}
 	pl, _ := g.node.ReceivePayload(data)
 	g.c.Set(dataStr, pl, cache.DefaultExpiration)
+	log.Trace("data being returned", "data", fmt.Sprintf("%v", pl))
 	return pl, nil
 }
 
@@ -47,7 +67,7 @@ func New(path string) (*Constellation, error) {
 	}
 	// We accept either the socket or a configuration file that points to
 	// a socket.
-	isSocket := info.Mode() & os.ModeSocket != 0
+	isSocket := info.Mode()&os.ModeSocket != 0
 	if !isSocket {
 		cfg, err := LoadConfig(path)
 		if err != nil {
@@ -64,12 +84,20 @@ func New(path string) (*Constellation, error) {
 		return nil, err
 	}
 	return &Constellation{
-		node: n,
-		c:    cache.New(5*time.Minute, 5*time.Minute),
+		node:   n,
+		c:      cache.New(5*time.Minute, 5*time.Minute),
+		ignore: false,
 	}, nil
 }
 
 func MustNew(path string) *Constellation {
+	if strings.EqualFold(path, "ignore") {
+		return &Constellation{
+			node:   nil,
+			c:      nil,
+			ignore: true,
+		}
+	}
 	g, err := New(path)
 	if err != nil {
 		panic(fmt.Sprintf("MustNew: Failed to connect to Constellation (%s): %v", path, err))

--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -12,9 +12,9 @@ import (
 )
 
 type Constellation struct {
-	node                 *Client
-	c                    *cache.Cache
-	isConstellationInUse bool
+	node                    *Client
+	c                       *cache.Cache
+	isConstellationNotInUse bool
 }
 
 var (
@@ -22,7 +22,7 @@ var (
 )
 
 func (g *Constellation) Send(data []byte, from string, to []string) (out []byte, err error) {
-	if g.isConstellationInUse {
+	if g.isConstellationNotInUse {
 		return nil, ErrConstellationIsntInit
 	}
 	out, err = g.node.SendPayload(data, from, to)
@@ -34,7 +34,7 @@ func (g *Constellation) Send(data []byte, from string, to []string) (out []byte,
 }
 
 func (g *Constellation) Receive(data []byte) ([]byte, error) {
-	if g.isConstellationInUse {
+	if g.isConstellationNotInUse {
 		return nil, nil
 	}
 	if len(data) == 0 {
@@ -78,18 +78,18 @@ func New(path string) (*Constellation, error) {
 		return nil, err
 	}
 	return &Constellation{
-		node:                 n,
-		c:                    cache.New(5*time.Minute, 5*time.Minute),
-		isConstellationInUse: false,
+		node: n,
+		c:    cache.New(5*time.Minute, 5*time.Minute),
+		isConstellationNotInUse: false,
 	}, nil
 }
 
 func MustNew(path string) *Constellation {
 	if strings.EqualFold(path, "ignore") {
 		return &Constellation{
-			node:                 nil,
-			c:                    nil,
-			isConstellationInUse: true,
+			node: nil,
+			c:    nil,
+			isConstellationNotInUse: true,
 		}
 	}
 	g, err := New(path)


### PR DESCRIPTION
fixes issue #300 - quorum no longer requires that you configure a constellation node.  Can define PRIVATE_CONFIG=ignore when setting up a quorum node to allow it to ignore private transactions