### PR TITLE
Transaction signer mismatch fix

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -220,7 +220,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		config:      config,
 		chainconfig: chainconfig,
 		chain:       chain,
-		signer:      types.MakeSigner(chainconfig, new(big.Int)),
+		signer:      types.NewEIP155Signer(chainconfig.ChainId),
 		pending:     make(map[common.Address]*txList),
 		queue:       make(map[common.Address]*txList),
 		beats:       make(map[common.Address]time.Time),

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 	"io/ioutil"
 	"os"
+	"reflect"
 )
 
 // testTxPoolConfig is a transaction pool configuration without stateful disk
@@ -1522,3 +1523,48 @@ func benchmarkPoolBatchInsert(b *testing.B, size int) {
 		pool.AddRemotes(batch)
 	}
 }
+
+//Checks that the EIP155 signer is assigned to the TxPool no matter the configuration, even invalid config
+func TestEIP155SignerOnTxPool(t *testing.T) {
+	var flagtests = []struct {
+		name string
+		homesteadBlock  *big.Int
+		eip155Block *big.Int
+	}{
+		{"hsnileip155nil", nil, nil},
+		{"hsnileip1550", nil, big.NewInt(0)},
+		{"hsnileip155100", nil, big.NewInt(100)},
+		{"hs0eip155nil", big.NewInt(0), nil},
+		{"hs0eip1550", big.NewInt(0), big.NewInt(0)},
+		{"hs0eip155100", big.NewInt(0), big.NewInt(100)},
+		{"hs100eip155nil", big.NewInt(100), nil},
+		{"hs100eip1550", big.NewInt(100), big.NewInt(0)},
+		{"hs100eip155100", big.NewInt(100), big.NewInt(100)},
+	}
+
+	for _, tt := range flagtests {
+		t.Run("", func(t *testing.T) {
+			db, _ := ethdb.NewMemDatabase()
+			statedb, _ := state.New(common.Hash{}, state.NewDatabase(db))
+			blockchain := &testBlockChain{statedb, big.NewInt(1000000), new(event.Feed)}
+
+			chainconfig := &params.ChainConfig{
+				ChainId:        big.NewInt(10),
+				HomesteadBlock: tt.homesteadBlock,
+				EIP150Block:    big.NewInt(0),
+				EIP155Block:    tt.eip155Block,
+				EIP158Block:    big.NewInt(0),
+				ByzantiumBlock: big.NewInt(0),
+				Ethash:         new(params.EthashConfig),
+			}
+
+			pool := NewTxPool(testTxPoolConfig, chainconfig, blockchain)
+
+			if reflect.TypeOf(types.EIP155Signer{}) != reflect.TypeOf(pool.signer) {
+				t.Fail()
+			}
+		})
+	}
+
+}
+

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -566,7 +566,7 @@ func (env *Work) commitTransactions(mux *event.TypeMux, txs *types.TransactionsB
 		from, _ := types.Sender(env.signer, tx)
 		// Check whether the tx is replay protected. If we're not in the EIP155 hf
 		// phase, start ignoring the sender until we do.
-		if tx.Protected() && !env.config.IsEIP155(env.header.Number) {
+		if tx.Protected() && !env.config.IsEIP155(env.header.Number) && !tx.IsPrivate() {
 			log.Trace("Ignoring reply protected transaction", "hash", tx.Hash(), "eip155", env.config.EIP155Block)
 
 			txs.Pop()


### PR DESCRIPTION
The application now assigns the EIP155 signer to the local transaction pool, so it can verify transactions signed by both the EIP155 and Homestead signer (instead of trying to use the Frontier signer to verify transactions).

When attempting to commit transactions from the transaction pool, skip over private transactions, regardless of whether we are in EIP155 or Homestead phase.