### PR TITLE
Feature/410/expose raft cluster api

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -628,7 +628,11 @@ web3._extend({
                new web3._extend.Property({
                        name: 'leader',
                        getter: 'raft_leader'
-               })
+               }),
+							 new web3._extend.Property({
+							 				name: 'cluster',
+							 				getter: 'raft_cluster'
+							 })
        ]
 })
 `

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -629,7 +629,7 @@ web3._extend({
                        name: 'leader',
                        getter: 'raft_leader'
                }),
-							 new web3._extend.Property({
+               new web3._extend.Property({
                        name: 'cluster',
                        getter: 'raft_cluster'
                }),

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -630,9 +630,9 @@ web3._extend({
                        getter: 'raft_leader'
                }),
 							 new web3._extend.Property({
-							 				name: 'cluster',
-							 				getter: 'raft_cluster'
-							 })
+                       name: 'cluster',
+                       getter: 'raft_cluster'
+               }),
        ]
 })
 `

--- a/raft/api.go
+++ b/raft/api.go
@@ -39,6 +39,6 @@ func (s *PublicRaftAPI) Leader() (string, error) {
 }
 
 func (s *PublicRaftAPI) Cluster() []*Address {
-	return append(s.raftService.raftProtocolManager.NodeInfo().PeerAddresses,
-		s.raftService.raftProtocolManager.NodeInfo().Address)
+	nodeInfo := s.raftService.raftProtocolManager.NodeInfo()
+	return append(nodeInfo.PeerAddresses, nodeInfo.Address)
 }

--- a/raft/api.go
+++ b/raft/api.go
@@ -39,5 +39,6 @@ func (s *PublicRaftAPI) Leader() (string, error) {
 }
 
 func (s *PublicRaftAPI) Cluster() []*Address {
-	return s.raftService.raftProtocolManager.NodeInfo().PeerAddresses
+	return append(s.raftService.raftProtocolManager.NodeInfo().PeerAddresses,
+		s.raftService.raftProtocolManager.NodeInfo().Address)
 }

--- a/raft/api.go
+++ b/raft/api.go
@@ -30,12 +30,12 @@ func (s *PublicRaftAPI) RemovePeer(raftId uint16) {
 	s.raftService.raftProtocolManager.ProposePeerRemoval(raftId)
 }
 
-func (s *PublicRaftAPI) Leader() (*Address, error) {
+func (s *PublicRaftAPI) Leader() (string, error) {
 	addr, err := s.raftService.raftProtocolManager.LeaderAddress()
 	if nil != err {
-		return nil, err
+		return "", err
 	}
-	return addr, nil
+	return addr.NodeId.String(), nil
 }
 
 func (s *PublicRaftAPI) Cluster() []*Address {

--- a/raft/api.go
+++ b/raft/api.go
@@ -37,3 +37,15 @@ func (s *PublicRaftAPI) Leader() (string, error) {
 	}
 	return addr.nodeId.String(), nil
 }
+
+func (s *PublicRaftAPI) Cluster() []*Address {
+	// infos := make([]*RaftPeerInfo, 0, len(s.raftService.raftProtocolManager.NodeInfo().PeerAddresses))
+	// for _, address := range s.raftService.raftProtocolManager.NodeInfo().PeerAddresses {
+	// 	if address != nil {
+	// 		infos = append(infos, address.toDisplay())
+	// 		log.Info("stuff", "raftinfo", fmt.Sprintf("%v", address.toDisplay()))
+	// 	}
+	// }
+	// return infos
+	return s.raftService.raftProtocolManager.NodeInfo().PeerAddresses
+}

--- a/raft/api.go
+++ b/raft/api.go
@@ -30,22 +30,14 @@ func (s *PublicRaftAPI) RemovePeer(raftId uint16) {
 	s.raftService.raftProtocolManager.ProposePeerRemoval(raftId)
 }
 
-func (s *PublicRaftAPI) Leader() (string, error) {
+func (s *PublicRaftAPI) Leader() (*Address, error) {
 	addr, err := s.raftService.raftProtocolManager.LeaderAddress()
 	if nil != err {
-		return "", err
+		return nil, err
 	}
-	return addr.nodeId.String(), nil
+	return addr, nil
 }
 
 func (s *PublicRaftAPI) Cluster() []*Address {
-	// infos := make([]*RaftPeerInfo, 0, len(s.raftService.raftProtocolManager.NodeInfo().PeerAddresses))
-	// for _, address := range s.raftService.raftProtocolManager.NodeInfo().PeerAddresses {
-	// 	if address != nil {
-	// 		infos = append(infos, address.toDisplay())
-	// 		log.Info("stuff", "raftinfo", fmt.Sprintf("%v", address.toDisplay()))
-	// 	}
-	// }
-	// return infos
 	return s.raftService.raftProtocolManager.NodeInfo().PeerAddresses
 }

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -624,17 +624,17 @@ func (pm *ProtocolManager) entriesToApply(allEntries []raftpb.Entry) (entriesToA
 }
 
 func raftUrl(address *Address) string {
-	return fmt.Sprintf("http://%s:%d", address.ip, address.raftPort)
+	return fmt.Sprintf("http://%s:%d", address.Ip, address.RaftPort)
 }
 
 func (pm *ProtocolManager) addPeer(address *Address) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
-	raftId := address.raftId
+	raftId := address.RaftId
 
 	// Add P2P connection:
-	p2pNode := discover.NewNode(address.nodeId, address.ip, 0, uint16(address.p2pPort))
+	p2pNode := discover.NewNode(address.NodeId, address.Ip, 0, uint16(address.P2pPort))
 	pm.p2pServer.AddPeer(p2pNode)
 
 	// Add raft transport connection:

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -14,29 +14,21 @@ import (
 // Serializable information about a Peer. Sufficient to build `etcdRaft.Peer`
 // or `discover.Node`.
 type Address struct {
-	raftId   uint16          `json:"raftId"`
-	nodeId   discover.NodeID `json:"nodeId"`
-	ip       net.IP          `json:"ip"`
-	p2pPort  uint16          `json:"p2pPort"`
-	raftPort uint16          `json:"raftPort"`
+	RaftId   uint16          `json:"raftId"`
+	NodeId   discover.NodeID `json:"nodeId"`
+	Ip       net.IP          `json:"ip"`
+	P2pPort  uint16          `json:"p2pPort"`
+	RaftPort uint16          `json:"raftPort"`
 }
 
 func newAddress(raftId uint16, raftPort uint16, node *discover.Node) *Address {
 	return &Address{
-		raftId:   raftId,
-		nodeId:   node.ID,
-		ip:       node.IP,
-		p2pPort:  node.TCP,
-		raftPort: raftPort,
+		RaftId:   raftId,
+		NodeId:   node.ID,
+		Ip:       node.IP,
+		P2pPort:  node.TCP,
+		RaftPort: raftPort,
 	}
-}
-
-type RaftPeerInfo struct {
-	raftId   string `json:"raftId"`
-	nodeId   string `json:"nodeId"`
-	ip       string `json:"ip"`
-	p2pPort  string `json:"p2pPort"`
-	raftPort string `json:"raftPort"`
 }
 
 // A peer that we're connected to via both raft's http transport, and ethereum p2p
@@ -46,7 +38,7 @@ type Peer struct {
 }
 
 func (addr *Address) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{addr.raftId, addr.nodeId, addr.ip, addr.p2pPort, addr.raftPort})
+	return rlp.Encode(w, []interface{}{addr.RaftId, addr.NodeId, addr.Ip, addr.P2pPort, addr.RaftPort})
 }
 
 func (addr *Address) DecodeRLP(s *rlp.Stream) error {
@@ -62,7 +54,7 @@ func (addr *Address) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&temp); err != nil {
 		return err
 	} else {
-		addr.raftId, addr.nodeId, addr.ip, addr.p2pPort, addr.raftPort = temp.RaftId, temp.NodeId, temp.Ip, temp.P2pPort, temp.RaftPort
+		addr.RaftId, addr.NodeId, addr.Ip, addr.P2pPort, addr.RaftPort = temp.RaftId, temp.NodeId, temp.Ip, temp.P2pPort, temp.RaftPort
 		return nil
 	}
 }
@@ -86,15 +78,4 @@ func bytesToAddress(bytes []byte) *Address {
 		log.Fatalf("failed to RLP-decode Address: %v", err)
 	}
 	return &addr
-}
-
-func (address *Address) toDisplay() *RaftPeerInfo {
-	info := &RaftPeerInfo{
-		raftId:   fmt.Sprintf("%v", address.raftId),
-		nodeId:   address.nodeId.String(),
-		ip:       address.ip.String(),
-		p2pPort:  fmt.Sprintf("%v", address.p2pPort),
-		raftPort: fmt.Sprintf("%v", address.raftPort),
-	}
-	return info
 }

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -5,19 +5,20 @@ import (
 	"net"
 
 	"fmt"
+	"log"
+
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/rlp"
-	"log"
 )
 
 // Serializable information about a Peer. Sufficient to build `etcdRaft.Peer`
 // or `discover.Node`.
 type Address struct {
-	raftId   uint16
-	nodeId   discover.NodeID
-	ip       net.IP
-	p2pPort  uint16
-	raftPort uint16
+	raftId   uint16          `json:"raftId"`
+	nodeId   discover.NodeID `json:"nodeId"`
+	ip       net.IP          `json:"ip"`
+	p2pPort  uint16          `json:"p2pPort"`
+	raftPort uint16          `json:"raftPort"`
 }
 
 func newAddress(raftId uint16, raftPort uint16, node *discover.Node) *Address {
@@ -28,6 +29,14 @@ func newAddress(raftId uint16, raftPort uint16, node *discover.Node) *Address {
 		p2pPort:  node.TCP,
 		raftPort: raftPort,
 	}
+}
+
+type RaftPeerInfo struct {
+	raftId   string `json:"raftId"`
+	nodeId   string `json:"nodeId"`
+	ip       string `json:"ip"`
+	p2pPort  string `json:"p2pPort"`
+	raftPort string `json:"raftPort"`
 }
 
 // A peer that we're connected to via both raft's http transport, and ethereum p2p
@@ -77,4 +86,15 @@ func bytesToAddress(bytes []byte) *Address {
 		log.Fatalf("failed to RLP-decode Address: %v", err)
 	}
 	return &addr
+}
+
+func (address *Address) toDisplay() *RaftPeerInfo {
+	info := &RaftPeerInfo{
+		raftId:   fmt.Sprintf("%v", address.raftId),
+		nodeId:   address.nodeId.String(),
+		ip:       address.ip.String(),
+		p2pPort:  fmt.Sprintf("%v", address.p2pPort),
+		raftPort: fmt.Sprintf("%v", address.raftPort),
+	}
+	return info
 }

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -30,7 +30,7 @@ type ByRaftId []Address
 
 func (a ByRaftId) Len() int           { return len(a) }
 func (a ByRaftId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a ByRaftId) Less(i, j int) bool { return a[i].raftId < a[j].raftId }
+func (a ByRaftId) Less(i, j int) bool { return a[i].RaftId < a[j].RaftId }
 
 func (pm *ProtocolManager) buildSnapshot() *Snapshot {
 	pm.mu.RLock()
@@ -140,17 +140,17 @@ func (pm *ProtocolManager) updateClusterMembership(newConfState raftpb.ConfState
 	for _, tempAddress := range addresses {
 		address := tempAddress // Allocate separately on the heap for each iteration.
 
-		if address.raftId == pm.raftId {
+		if address.RaftId == pm.raftId {
 			// If we're a newcomer to an existing cluster, this is where we learn
 			// our own Address.
 			pm.setLocalAddress(&address)
 		} else {
 			pm.mu.RLock()
-			existingPeer := pm.peers[address.raftId]
+			existingPeer := pm.peers[address.RaftId]
 			pm.mu.RUnlock()
 
 			if existingPeer == nil {
-				log.Info("adding new raft peer", "raft id", address.raftId)
+				log.Info("adding new raft peer", "raft id", address.RaftId)
 				pm.addPeer(&address)
 			}
 		}


### PR DESCRIPTION
Give users the ability to see raft cluster information. raft.cluster exposes info of all the peers in the cluster (in pm.peers) including the raftId, nodeId, ip address, raft port, p2p port.  This can be used to check that all raft nodes came up that were expected.  Also can be used along with admin.peers to make sure the network was configured properly