### PR TITLE
bugfix/istanbul-storeBacklog-memory-leak

### DIFF
--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -30,11 +30,11 @@ type defaultValidator struct {
 	address common.Address
 }
 
-func (val *defaultValidator) Address() common.Address {
+func (val defaultValidator) Address() common.Address {
 	return val.address
 }
 
-func (val *defaultValidator) String() string {
+func (val defaultValidator) String() string {
 	return val.Address().String()
 }
 

--- a/consensus/istanbul/validator/validator.go
+++ b/consensus/istanbul/validator/validator.go
@@ -22,7 +22,7 @@ import (
 )
 
 func New(addr common.Address) istanbul.Validator {
-	return &defaultValidator{
+	return defaultValidator{
 		address: addr,
 	}
 }


### PR DESCRIPTION
defaultValidator being a pointer is causing problem when adding future messages to the backlogs map. Because of pointers (probably after items being copied around) not being equal even though the values are, this map will slowly growing and potentially cause a memory leak at some point