### PR TITLE
Disallow p2p or raft port reuse for raft consensus

### DIFF
--- a/raft/handler.go
+++ b/raft/handler.go
@@ -274,17 +274,28 @@ func (pm *ProtocolManager) isRaftIdUsed(raftId uint16) bool {
 	return pm.peers[raftId] != nil
 }
 
-func (pm *ProtocolManager) isP2pNodeInCluster(node *discover.Node) bool {
+func (pm *ProtocolManager) isNodeAlreadyInCluster(node *discover.Node) error {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 
 	for _, peer := range pm.peers {
-		if peer.p2pNode.ID == node.ID {
-			return true
+		peerRaftId := peer.address.RaftId
+		peerNode := peer.p2pNode
+
+		if peerNode.ID == node.ID {
+			return fmt.Errorf("node with this enode has already been added to the cluster: %v", node.ID)
+		}
+
+		if peerNode.IP.Equal(node.IP) {
+			if peerNode.TCP == node.TCP {
+				return fmt.Errorf("existing node %v with raft ID %v is already using eth p2p at %v:%v", peerNode.ID, peerRaftId, node.IP, node.TCP)
+			} else if peer.address.RaftPort == node.RaftPort {
+				return fmt.Errorf("existing node %v with raft ID %v is already using raft at %v:%v", peerNode.ID, peerRaftId, node.IP, node.RaftPort)
+			}
 		}
 	}
 
-	return false
+	return nil
 }
 
 func (pm *ProtocolManager) ProposeNewPeer(enodeId string) (uint16, error) {
@@ -293,16 +304,16 @@ func (pm *ProtocolManager) ProposeNewPeer(enodeId string) (uint16, error) {
 		return 0, err
 	}
 
-	if pm.isP2pNodeInCluster(node) {
-		return 0, fmt.Errorf("node is already in the cluster: %v", enodeId)
-	}
-
 	if len(node.IP) != 4 {
 		return 0, fmt.Errorf("expected IPv4 address (with length 4), but got IP of length %v", len(node.IP))
 	}
 
 	if !node.HasRaftPort() {
 		return 0, fmt.Errorf("enodeId is missing raftport querystring parameter: %v", enodeId)
+	}
+
+	if err := pm.isNodeAlreadyInCluster(node); err != nil {
+		return 0, err
 	}
 
 	raftId := pm.nextRaftId()


### PR DESCRIPTION
Fixes #411

When the user tries to do `raft.addPeer(ENODE)`, we now make sure that the (IP, raft port) and (IP, eth port) tuples are not already in use. After a peer is removed, those tuples are again usable.

I also made a slight tweak to do the input validation before checking whether the node already exists in cluster.

If I follow the steps that Felix describes, I now get the following transcript:

```
> raft.addPeer("enode://0885924189911c149fa4955c01c9cd69642501e5fa2f583f2ea65284b397962a2fb53532c6fe2a08c027da0923b2e37e495b989cc5c743b9cafb040cb729e746@127.0.0.1:55550?raftport=55555")
8
> raft.addPeer("enode://1b4e0d26c031ab3e56598b6e5436539b419d29af58cc547d8eb06262e98eb0202b61916a696b3adb0fbf2be09daaf548abd68b69e944f0d818da8a779bc51c59@127.0.0.1:55550?raftport=55555")
Error: existing node 0885924189911c149fa4955c01c9cd69642501e5fa2f583f2ea65284b397962a2fb53532c6fe2a08c027da0923b2e37e495b989cc5c743b9cafb040cb729e746 with raft ID 8 is already using eth p2p at 127.0.0.1:55550
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1

> raft.removePeer(8)
null
> raft.addPeer("enode://1b4e0d26c031ab3e56598b6e5436539b419d29af58cc547d8eb06262e98eb0202b61916a696b3adb0fbf2be09daaf548abd68b69e944f0d818da8a779bc51c59@127.0.0.1:55550?raftport=55555")
9
> // We can also try adding the same node twice:
> raft.addPeer("enode://1b4e0d26c031ab3e56598b6e5436539b419d29af58cc547d8eb06262e98eb0202b61916a696b3adb0fbf2be09daaf548abd68b69e944f0d818da8a779bc51c59@127.0.0.1:55550?raftport=55555")
Error: node with this enode has already been added to the cluster: 1b4e0d26c031ab3e56598b6e5436539b419d29af58cc547d8eb06262e98eb0202b61916a696b3adb0fbf2be09daaf548abd68b69e944f0d818da8a779bc51c59
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1

>
> raft.removePeer(9)
null
>
raft.addPeer("enode://1b4e0d26c031ab3e56598b6e5436539b419d29af58cc547d8eb06262e98eb0202b61916a696b3adb0fbf2be09daaf548abd68b69e944f0d818da8a779bc51c59@127.0.0.1:55550?raftport=55555")
10