### PR TITLE
Dockerfile: add bootnode to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,15 @@ FROM golang:1.9-alpine as builder
 RUN apk add --no-cache make gcc musl-dev linux-headers
 
 ADD . /go-ethereum
-RUN cd /go-ethereum && make geth
+RUN cd /go-ethereum && make geth bootnode
 
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+COPY --from=builder /go-ethereum/build/bin/bootnode /usr/local/bin/
+
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ geth:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
+bootnode:
+	build/env.sh go run build/ci.go install ./cmd/bootnode
+	@echo "Done building bootnode."
+
 swarm:
 	build/env.sh go run build/ci.go install ./cmd/swarm
 	@echo "Done building."


### PR DESCRIPTION
`bootnode` has functionalities to generate node key and marshal to node id which are useful for bootstraping local Quorum network from scratch.