### PR TITLE
Value Transfer in Private Transactions

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -585,7 +585,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrNonceTooLow
 	}
 	// Ether value is not currently supported on private transactions
-	if tx.IsPrivate() && len(tx.Data()) == 0 {
+	if tx.IsPrivate() && (len(tx.Data()) == 0 || tx.Value().Sign() != 0) {
 		return ErrEtherValueUnsupported
 	}
 	// Transactor should have enough funds to cover the costs

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -585,8 +585,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrNonceTooLow
 	}
 	// Ether value is not currently supported on private transactions
-	if tx.IsPrivate() && (tx.Value().Sign() != 0) {
-		return ErrEtherValueUnsupported;
+	if tx.IsPrivate() && len(tx.Data()) == 0 {
+		return ErrEtherValueUnsupported
 	}
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -19,8 +19,14 @@ package core
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"io/ioutil"
 	"math/big"
+	"math/rand"
+	"os"
+	"reflect"
 	"testing"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -28,11 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
-	"math/rand"
-	"time"
-	"io/ioutil"
-	"os"
-	"reflect"
 )
 
 // testTxPoolConfig is a transaction pool configuration without stateful disk
@@ -279,6 +280,37 @@ func TestQuorumInvalidTransactions(t *testing.T) {
 		t.Error("expected", ErrInvalidGasPrice, "; got", err)
 	}
 
+}
+
+func TestValidateTx_whenValueZeroTransferForPrivateTransaction(t *testing.T) {
+	pool, key := setupQuorumTxPool()
+	defer pool.Stop()
+	zeroValue := common.Big0
+	zeroGasPrice := common.Big0
+	defaultTxPoolGasLimit := big.NewInt(1000000)
+	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, zeroGasPrice, nil), types.HomesteadSigner{}, key)
+	arbitraryTx.SetPrivate()
+
+	if err := pool.AddRemote(arbitraryTx); err != ErrEtherValueUnsupported {
+		t.Error("expected:", ErrEtherValueUnsupported, "; got:", err)
+	}
+}
+
+func TestValidateTx_whenValueNonZeroTransferForPrivateTransaction(t *testing.T) {
+	pool, key := setupQuorumTxPool()
+	defer pool.Stop()
+	arbitraryValue := common.Big3
+	zeroGasPrice := common.Big0
+	defaultTxPoolGasLimit := big.NewInt(1000000)
+	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, arbitraryValue, defaultTxPoolGasLimit, zeroGasPrice, nil), types.HomesteadSigner{}, key)
+	arbitraryTx.SetPrivate()
+	balance := new(big.Int).Add(arbitraryTx.Value(), new(big.Int).Mul(arbitraryTx.Gas(), arbitraryTx.GasPrice()))
+	from, _ := deriveSender(arbitraryTx)
+	pool.currentState.AddBalance(from, balance)
+
+	if err := pool.AddRemote(arbitraryTx); err != ErrEtherValueUnsupported {
+		t.Error("expected: ", ErrEtherValueUnsupported, "; got:", err)
+	}
 }
 
 func TestTransactionQueue(t *testing.T) {
@@ -1527,9 +1559,9 @@ func benchmarkPoolBatchInsert(b *testing.B, size int) {
 //Checks that the EIP155 signer is assigned to the TxPool no matter the configuration, even invalid config
 func TestEIP155SignerOnTxPool(t *testing.T) {
 	var flagtests = []struct {
-		name string
-		homesteadBlock  *big.Int
-		eip155Block *big.Int
+		name           string
+		homesteadBlock *big.Int
+		eip155Block    *big.Int
 	}{
 		{"hsnileip155nil", nil, nil},
 		{"hsnileip1550", nil, big.NewInt(0)},
@@ -1567,4 +1599,3 @@ func TestEIP155SignerOnTxPool(t *testing.T) {
 	}
 
 }
-


### PR DESCRIPTION
* Fix #528 
* Added support for private transaction in `eth_signTransaction` API (useful in conjunction with `eth_SendRawTransaction` API when dealing with private transactions)