### PR TITLE
docker: Add git commit hash

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-**/.git
 **/*_test.go
 
 build/_workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Geth in a stock Go builder container
 FROM golang:1.9-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers
+RUN apk add --no-cache make gcc musl-dev linux-headers git
 
 ADD . /go-ethereum
 RUN cd /go-ethereum && make geth bootnode

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOBIN = $(shell pwd)/build/bin
 GO ?= latest
 
 geth:
-	build/env.sh go run build/ci.go install -git-commit=${SOURCE_COMMIT} -git-branch=${SOURCE_BRANCH} ./cmd/geth
+	build/env.sh go run build/ci.go install -git-commit=$(SOURCE_COMMIT) -git-branch=$(SOURCE_BRANCH) ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOBIN = $(shell pwd)/build/bin
 GO ?= latest
 
 geth:
-	build/env.sh go run build/ci.go install -git-commit=$(SOURCE_COMMIT) -git-branch=$(SOURCE_BRANCH) ./cmd/geth
+	build/env.sh go run build/ci.go install ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOBIN = $(shell pwd)/build/bin
 GO ?= latest
 
 geth:
-	build/env.sh go run build/ci.go install ./cmd/geth
+	build/env.sh go run build/ci.go install -git-commit=${SOURCE_COMMIT} -git-branch=${SOURCE_BRANCH} ./cmd/geth
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 


### PR DESCRIPTION
When building Docker Image, the Git Commit Hash is missing from `geth`.

This is to fix this issue.