### PR TITLE
p2p: remove spurious log for denied node permissioning

### DIFF
--- a/p2p/permissions.go
+++ b/p2p/permissions.go
@@ -30,7 +30,6 @@ func isNodePermissioned(nodename string, currentNode string, datadir string, dir
 			log.Debug("isNodePermissioned", "connection", direction, "nodename", nodename[:NODE_NAME_LENGTH], "ALLOWED-BY", currentNode[:NODE_NAME_LENGTH])
 			return true
 		}
-		log.Debug("isNodePermissioned", "connection", direction, "nodename", nodename[:NODE_NAME_LENGTH], "DENIED-BY", currentNode[:NODE_NAME_LENGTH])
 	}
 	log.Debug("isNodePermissioned", "connection", direction, "nodename", nodename[:NODE_NAME_LENGTH], "DENIED-BY", currentNode[:NODE_NAME_LENGTH])
 	return false


### PR DESCRIPTION
connection is only denied after cycling through entire list, remove
confusing and erroneous log in the loop