### PR TITLE
Do not reset V value if the tx is already set to private

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -486,6 +486,9 @@ func (tx *Transaction) IsPrivate() bool {
 }
 
 func (tx *Transaction) SetPrivate() {
+	if tx.IsPrivate() {
+		return
+	}
 	if tx.data.V.Int64() == 28 {
 		tx.data.V.SetUint64(38)
 	} else {


### PR DESCRIPTION
When trying to send a private RawTransaction, the V value gets reset irrespective of what it previously was set to. 