### PR TITLE
Adding private log blooms to DB in addition to public log bloom

### DIFF
--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -63,6 +63,14 @@ func (b *Bloom) Add(d *big.Int) {
 	b.SetBytes(bin.Bytes())
 }
 
+// OrBloom executes an Or operation on the bloom
+func (b *Bloom) OrBloom(bl []byte) {
+	bin := new(big.Int).SetBytes(b[:])
+	input := new(big.Int).SetBytes(bl[:])
+	bin.Or(bin, input)
+	b.SetBytes(bin.Bytes())
+}
+
 // Big converts b to a big integer.
 func (b Bloom) Big() *big.Int {
 	return new(big.Int).SetBytes(b[:])

--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -119,10 +119,14 @@ func (b *BloomIndexer) Reset(section uint64) {
 	b.gen, b.section, b.head = gen, section, common.Hash{}
 }
 
-// Process implements core.ChainIndexerBackend, adding a new header's bloom into
-// the index.
+// Process implements core.ChainIndexerBackend, executes an Or operation on header.bloom and private bloom
+// (header.bloom | private bloom) and adds to index
 func (b *BloomIndexer) Process(header *types.Header) {
-	b.gen.AddBloom(uint(header.Number.Uint64()-b.section*b.size), header.Bloom)
+	publicBloom := header.Bloom
+	privateBloom := core.GetPrivateBlockBloom(b.db, header.Number.Uint64())
+	publicBloom.OrBloom(privateBloom.Bytes())
+
+	b.gen.AddBloom(uint(header.Number.Uint64()-b.section*b.size), publicBloom)
 	b.head = header.Hash()
 }
 


### PR DESCRIPTION
Private transactions log blooms are not indexed by the bloom indexer and as a result after logs indexing, private transaction logs and events are not retrieved by `eth_getLogs()` call. 

As part of this PR, the private log bloom is read from DB and is `OR'd` with public log blooms and stored in DB. 