### PR TITLE
core/tx_pool_test: fix method signature

### DIFF
--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -279,7 +279,7 @@ func TestInvalidTransactions(t *testing.T) {
 	}
 
 	data := make([]byte, (64*1024)+1)
-	tx2, _ := types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(100), big.NewInt(100000), big.NewInt(1), data), types.HomesteadSigner{}, key)
+	tx2, _ := types.SignTx(types.NewTransaction(2, common.Address{}, big.NewInt(100), 100000, big.NewInt(1), data), types.HomesteadSigner{}, key)
 	if err := pool.AddRemote(tx2); err != ErrOversizedData {
 		t.Error("expected", ErrOversizedData, "; got", err)
 	}


### PR DESCRIPTION
There's a change in method signature, fix the test to reflect the same