### PR TITLE
Fix node crash when minter is not a participant in private contract and fix estimate gas issue

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -612,7 +612,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		if err != nil {
 			return ErrPrivateDataNotFound
 		}
-		data = privateData
+		if privateData != nil {
+			data = privateData
+		}
 	}
 	intrGas, err := IntrinsicGas(data, tx.To() == nil, pool.homestead)
 	if err != nil {


### PR DESCRIPTION
This PR fixes an issue when nodes party to a private contract crash due to running out of gas when executing transactions in the block and the Minter is not party to transaction.
The PR also fixes high gas estimate issues

Fixes #461 