### PR TITLE
tests/: minor refactoring to enable Ethereum tests

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-	set "gopkg.in/fatih/set.v0"
+	"gopkg.in/fatih/set.v0"
 )
 
 // Ethash proof-of-work protocol constants.
@@ -285,9 +285,9 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainReader, header, parent *
 	if diff < 0 {
 		diff *= -1
 	}
-	limit := parent.GasLimit / params.GasLimitBoundDivisor
+	limit := parent.GasLimit / params.OriginalGasLimitBoundDivisor
 
-	if uint64(diff) >= limit || header.GasLimit < params.MinGasLimit {
+	if uint64(diff) >= limit || header.GasLimit < params.OriginnalMinGasLimit {
 		return fmt.Errorf("invalid gas limit: have %d, want %d += %d", header.GasLimit, parent.GasLimit, limit)
 	}
 	// Verify that the block number is parent's +1

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -21,15 +21,18 @@ import "math/big"
 var (
 	TargetGasLimit = GenesisGasLimit // The artificial target
 
-	// the followings are modified by Quorum and purposely moved from `const` section
-	// so to faclitate the execution of Ethereum Tests
-	// @see tests/init_test.go#TestMain
-	GasLimitBoundDivisor uint64 = 4096      // The bound divisor of the gas limit, used in update calculations.
-	MinGasLimit          uint64 = 700000000 // Minimum the gas limit may ever be.
-	GenesisGasLimit      uint64 = 800000000 // Gas limit of the Genesis block.
 )
 
 const (
+	// these are original values from upstream Geth, used in ethash consensus
+	OriginnalMinGasLimit         uint64 = 5000 // The bound divisor of the gas limit, used in update calculations.
+	OriginalGasLimitBoundDivisor uint64 = 1024 // Minimum the gas limit may ever be.
+
+	// modified values for Quorum
+	GasLimitBoundDivisor uint64 = 4096      // The bound divisor of the gas limit, used in update calculations.
+	MinGasLimit          uint64 = 700000000 // Minimum the gas limit may ever be.
+	GenesisGasLimit      uint64 = 800000000 // Gas limit of the Genesis block.
+
 	MaximumExtraDataSize  uint64 = 32    // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10    // Times ceil(log256(exponent)) for the EXP instruction.
 	SloadGas              uint64 = 50    // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -20,13 +20,16 @@ import "math/big"
 
 var (
 	TargetGasLimit = GenesisGasLimit // The artificial target
-)
 
-const (
+	// the followings are modified by Quorum and purposely moved from `const` section
+	// so to faclitate the execution of Ethereum Tests
+	// @see tests/init_test.go#TestMain
 	GasLimitBoundDivisor uint64 = 4096      // The bound divisor of the gas limit, used in update calculations.
 	MinGasLimit          uint64 = 700000000 // Minimum the gas limit may ever be.
 	GenesisGasLimit      uint64 = 800000000 // Gas limit of the Genesis block.
+)
 
+const (
 	MaximumExtraDataSize  uint64 = 32    // Maximum size extra data may be after Genesis.
 	ExpByteGas            uint64 = 10    // Times ceil(log256(exponent)) for the EXP instruction.
 	SloadGas              uint64 = 50    // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -261,12 +261,3 @@ func runTestFunc(runTest interface{}, t *testing.T, name string, m reflect.Value
 		m.MapIndex(reflect.ValueOf(key)),
 	})
 }
-
-func TestMain(m *testing.M) {
-	params.GasLimitBoundDivisor = 1024
-	params.MinGasLimit = 5000
-	params.GenesisGasLimit = 4712388
-
-	retCode := m.Run()
-	os.Exit(retCode)
-}

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -261,3 +261,20 @@ func runTestFunc(runTest interface{}, t *testing.T, name string, m reflect.Value
 		m.MapIndex(reflect.ValueOf(key)),
 	})
 }
+
+func TestMain(m *testing.M) {
+	backupMinGasLimit := params.MinGasLimit
+	backupGasLimitBoundDivisor := params.GasLimitBoundDivisor
+	backupGenesisGasLimit := params.GenesisGasLimit
+	defer func() {
+		params.GasLimitBoundDivisor = backupGasLimitBoundDivisor
+		params.MinGasLimit = backupMinGasLimit
+		params.GenesisGasLimit = backupGenesisGasLimit
+	}()
+	params.GasLimitBoundDivisor = 1024
+	params.MinGasLimit = 5000
+	params.GenesisGasLimit = 4712388
+
+	retCode := m.Run()
+	os.Exit(retCode)
+}

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -263,14 +263,6 @@ func runTestFunc(runTest interface{}, t *testing.T, name string, m reflect.Value
 }
 
 func TestMain(m *testing.M) {
-	backupMinGasLimit := params.MinGasLimit
-	backupGasLimitBoundDivisor := params.GasLimitBoundDivisor
-	backupGenesisGasLimit := params.GenesisGasLimit
-	defer func() {
-		params.GasLimitBoundDivisor = backupGasLimitBoundDivisor
-		params.MinGasLimit = backupMinGasLimit
-		params.GenesisGasLimit = backupGenesisGasLimit
-	}()
 	params.GasLimitBoundDivisor = 1024
 	params.MinGasLimit = 5000
 	params.GenesisGasLimit = 4712388


### PR DESCRIPTION
Tests under `tests` folder are against common [Ethereum tests](https://github.com/ethereum/tests) for all clients. 

As there're modification in protocol for Quorum (gas limit), those tests are failing.

This PR is an attempt to make sure those tests run again.