### PR TITLE
added dual state implementation to StaticCall

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -334,6 +334,10 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 	if evm.vmConfig.NoRecursion && evm.depth > 0 {
 		return nil, gas, nil
 	}
+
+	evm.Push(getDualState(evm, addr))
+	defer func() { evm.Pop() }()
+
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -335,9 +335,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 		return nil, gas, nil
 	}
 
-	evm.Push(getDualState(evm, addr))
-	defer func() { evm.Pop() }()
-
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
 		return nil, gas, ErrDepth
@@ -352,20 +349,21 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 
 	var (
 		to       = AccountRef(addr)
-		snapshot = evm.StateDB.Snapshot()
+		stateDb  = getDualState(evm, addr)
+		snapshot = stateDb.Snapshot()
 	)
 	// Initialise a new contract and set the code that is to be used by the
 	// EVM. The contract is a scoped environment for this execution context
 	// only.
 	contract := NewContract(caller, to, new(big.Int), gas)
-	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
+	contract.SetCallCode(&addr, stateDb.GetCodeHash(addr), stateDb.GetCode(addr))
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
 	// when we're in Homestead this also counts for code storage gas errors.
 	ret, err = run(evm, contract, input)
 	if err != nil {
-		evm.StateDB.RevertToSnapshot(snapshot)
+		stateDb.RevertToSnapshot(snapshot)
 		if err != errExecutionReverted {
 			contract.UseGas(contract.Gas)
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -173,7 +173,6 @@ func (in *Interpreter) Run(contract *Contract, input []byte) (ret []byte, err er
 
 		// Get the operation from the jump table and validate the stack to ensure there are
 		// enough stack items available to perform the operation.
-		op = contract.GetOp(pc)
 		operation := in.cfg.JumpTable[op]
 		if !operation.valid {
 			return nil, fmt.Errorf("invalid opcode 0x%x", int(op))


### PR DESCRIPTION
In [Solc 0.5.0](https://solidity.readthedocs.io/en/latest/050-breaking-changes.html), `view` and `pure` functions are now using STATICCALL opcode which had been an experimental from 0.4.21.

`core/vm/evm.go#StaticCall()` does not have the logic to handle dual state approach like `Call()` and `DelegateCall()` implementation. 

This causes issue when cross contract interaction using STATICCALL opcode. E.g.: reading a value from an external contract.

This PR is an attempt to fix the above issue and include a minor refactoring to remove a redundant statement in `interpreter.go`