### PR TITLE
Prevent deadlock when miner.setEtherbase is called for Istanbul consensus

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -356,12 +356,13 @@ func (s *Ethereum) Etherbase() (eb common.Address, err error) {
 // set in js console via admin interface or wrapper from cli flags
 func (s *Ethereum) SetEtherbase(etherbase common.Address) {
 	s.lock.Lock()
+	defer s.lock.Unlock()
 	if _, ok := s.engine.(consensus.Istanbul); ok {
 		log.Error("Cannot set etherbase in Istanbul consensus")
 		return
 	}
 	s.etherbase = etherbase
-	s.lock.Unlock()
+
 
 	s.miner.SetEtherbase(etherbase)
 }


### PR DESCRIPTION
Fixes deadlock caused when `miner.setEtherbase()` is called when Istanbul consensus is used