### PR TITLE
Raft: process sync data in parallel to download

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1693,7 +1693,7 @@ func (d *Downloader) syncWithPeerUntil(p *peerConnection, hash common.Hash, td *
 		func() error { return d.fetchBodies(localHeight + 1) },
 		func() error { return d.fetchReceipts(localHeight + 1) }, // Receipts are only retrieved during fast sync
 		func() error { return d.processHeaders(localHeight+1, pivot, td) },
-		d.processFullSyncContent,
+		d.processFullSyncContent, //This must be added to clear the buffer of downloaded content as it's being filled
 	}
 	return d.spawnSync(fetchers)
 }

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -397,11 +397,7 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode 
 		return errUnknownPeer
 	}
 	if d.mode == BoundedFullSync {
-		err := d.syncWithPeerUntil(p, hash, td)
-		if err == nil {
-			d.processFullSyncContent()
-		}
-		return err
+		return d.syncWithPeerUntil(p, hash, td)
 	}
 	return d.syncWithPeer(p, hash, td)
 }
@@ -1697,6 +1693,7 @@ func (d *Downloader) syncWithPeerUntil(p *peerConnection, hash common.Hash, td *
 		func() error { return d.fetchBodies(localHeight + 1) },
 		func() error { return d.fetchReceipts(localHeight + 1) }, // Receipts are only retrieved during fast sync
 		func() error { return d.processHeaders(localHeight+1, pivot, td) },
+		d.processFullSyncContent,
 	}
 	return d.spawnSync(fetchers)
 }


### PR DESCRIPTION
When synchronising with a peer in a raft-based network, data is downloaded from the peers but not processed until all data is downloaded.
Since there is a buffer to avoid overloading the node with more data than it can handle, the node throttles itself until some of the downloaded data is processed - however, since we aren't processing, we end up throttling permanently, stalling the download process indefinitely.

This change allows processing of data to happen in parallel to downloading, meaning the node stops throttling and continues the download.

Fixes https://github.com/jpmorganchase/quorum/issues/614