### PR TITLE
Re-enable gas price

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -349,11 +348,7 @@ func (bc *BlockChain) GasLimit() uint64 {
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()
 
-	if bc.Config().IsQuorum {
-		return math.MaxBig256.Uint64() // HACK(joel) a very large number
-	} else {
-		return bc.CurrentBlock().GasLimit()
-	}
+	return bc.CurrentBlock().GasLimit()
 }
 
 // CurrentBlock retrieves the current head block of the canonical chain. The

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -102,10 +102,6 @@ func ApplyTransaction(config *params.ChainConfig, bc *BlockChain, author *common
 		privateState = statedb
 	}
 
-	if config.IsQuorum && tx.GasPrice() != nil && tx.GasPrice().Cmp(common.Big0) > 0 {
-		return nil, nil, 0, ErrInvalidGasPrice
-	}
-
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
 	if err != nil {
 		return nil, nil, 0, err

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -265,8 +265,10 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 			return nil, 0, false, vmerr
 		}
 	}
-	st.refundGas()
-	st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
+	if !isPrivate {
+		st.refundGas()
+		st.state.AddBalance(st.evm.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
+	}
 
 	if isPrivate {
 		return ret, 0, vmerr != nil, err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -77,6 +77,8 @@ var (
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
 
+	ErrInvalidGasPrice = errors.New("Gas price not 0")
+
 	// ErrEtherValueUnsupported is returned if a transaction specifies an Ether Value
 	// for a private Quorum transaction.
 	ErrEtherValueUnsupported = errors.New("ether value is not supported for private transactions")

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -77,8 +77,6 @@ var (
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
 
-	ErrInvalidGasPrice = errors.New("Gas price not 0")
-
 	// ErrEtherValueUnsupported is returned if a transaction specifies an Ether Value
 	// for a private Quorum transaction.
 	ErrEtherValueUnsupported = errors.New("ether value is not supported for private transactions")

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -148,7 +148,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 0;
+	PriceLimit: 0,
 	PriceBump:  10,
 
 	AccountSlots: 16,
@@ -722,7 +722,6 @@ func (pool *TxPool) journalTx(from common.Address, tx *types.Transaction) {
 	}
 }
 
-
 // promoteTx adds a transaction to the pending (processable) list of transactions
 // and returns whether it was inserted or an older was better.
 //
@@ -1203,7 +1202,6 @@ func newTxLookup() *txLookup {
 		all: make(map[common.Hash]*types.Transaction),
 	}
 }
-
 
 // Range calls f on each key and value present in the map.
 func (t *txLookup) Range(f func(hash common.Hash, tx *types.Transaction) bool) {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -148,7 +148,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	PriceLimit: 0,
 	PriceBump:  10,
 
 	AccountSlots: 16,
@@ -161,7 +161,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 
 // sanitize checks the provided user configurations and changes anything that's
 // unreasonable or unworkable.
-func (config *TxPoolConfig) sanitize(isQuorum bool) TxPoolConfig {
+func (config *TxPoolConfig) sanitize() TxPoolConfig {
 	conf := *config
 	if conf.Rejournal < time.Second {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
@@ -170,10 +170,6 @@ func (config *TxPoolConfig) sanitize(isQuorum bool) TxPoolConfig {
 	if conf.PriceLimit < 1 {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultTxPoolConfig.PriceLimit)
 		conf.PriceLimit = DefaultTxPoolConfig.PriceLimit
-	}
-	if isQuorum && (conf.PriceLimit == DefaultTxPoolConfig.PriceLimit) {
-		log.Warn("Sanitizing invalid txpool price limit for Quorum", "provided", conf.PriceLimit, "updated 0")
-		conf.PriceLimit = 0
 	}
 	if conf.PriceBump < 1 {
 		log.Warn("Sanitizing invalid txpool price bump", "provided", conf.PriceBump, "updated", DefaultTxPoolConfig.PriceBump)
@@ -223,7 +219,7 @@ type TxPool struct {
 // transactions from the network.
 func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain blockChain) *TxPool {
 	// Sanitize the input to ensure no vulnerable gas prices are set
-	config = (&config).sanitize(chainconfig.IsQuorum)
+	config = (&config).sanitize()
 
 	// Create the transaction pool with its initial settings
 	pool := &TxPool{

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -77,8 +77,6 @@ var (
 	// making the transaction invalid, rather a DOS protection.
 	ErrOversizedData = errors.New("oversized data")
 
-	ErrInvalidGasPrice = errors.New("Gas price not 0")
-
 	// ErrEtherValueUnsupported is returned if a transaction specifies an Ether Value
 	// for a private Quorum transaction.
 	ErrEtherValueUnsupported = errors.New("ether value is not supported for private transactions")
@@ -559,11 +557,6 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	isQuorum := pool.chainconfig.IsQuorum
-
-	if isQuorum && tx.GasPrice().Cmp(common.Big0) != 0 {
-		return ErrInvalidGasPrice
-	}
 	// Heuristic limit, reject transactions over 32KB to prevent DOS attacks
 	// UPDATED to 64KB to support the deployment of bigger contract due to the pressing need for sophisticated/complex contract in financial/capital markets - Nathan Aw
 	if tx.Size() > 64*1024 {
@@ -585,7 +578,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
-	if !isQuorum && !local && pool.gasPrice.Cmp(tx.GasPrice()) > 0 {
+	if !local && pool.gasPrice.Cmp(tx.GasPrice()) > 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering
@@ -635,7 +628,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (bool, error) {
 	// If the transaction pool is full, discard underpriced transactions
 	if uint64(pool.all.Count()) >= pool.config.GlobalSlots+pool.config.GlobalQueue {
 		// If the new transaction is underpriced, don't accept it
-		if !pool.chainconfig.IsQuorum && !local && pool.priced.Underpriced(tx, pool.locals) {
+		if !local && pool.priced.Underpriced(tx, pool.locals) {
 			log.Trace("Discarding underpriced transaction", "hash", hash, "price", tx.GasPrice())
 			underpricedTxCounter.Inc(1)
 			return false, ErrUnderpriced
@@ -947,16 +940,14 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) {
 			pool.all.Remove(hash)
 			pool.priced.Removed()
 		}
-		if !isQuorum {
-			// Drop all transactions that are too costly (low balance or out of gas)
-			drops, _ := list.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas)
-			for _, tx := range drops {
-				hash := tx.Hash()
-				log.Trace("Removed unpayable queued transaction", "hash", hash)
-				pool.all.Remove(hash)
-				pool.priced.Removed()
-				queuedNofundsCounter.Inc(1)
-			}
+		// Drop all transactions that are too costly (low balance or out of gas)
+		drops, _ := list.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas)
+		for _, tx := range drops {
+			hash := tx.Hash()
+			log.Trace("Removed unpayable queued transaction", "hash", hash)
+			pool.all.Remove(hash)
+			pool.priced.Removed()
+			queuedNofundsCounter.Inc(1)
 		}
 		// Gather all executable transactions and promote them
 		for _, tx := range list.Ready(pool.pendingState.GetNonce(addr)) {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -148,7 +148,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	PriceLimit: 0;
 	PriceBump:  10,
 
 	AccountSlots: 16,

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -301,7 +301,6 @@ func TestValidateTx_whenValueZeroTransferForPrivateTransaction(t *testing.T) {
 	defer pool.Stop()
 	zeroValue := common.Big0
 	gasPrice := common.Big2
-
 	defaultTxPoolGasLimit := uint64(1000000)
 	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, gasPrice, nil), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()
@@ -325,7 +324,6 @@ func TestValidateTx_whenValueNonZeroTransferForPrivateTransaction(t *testing.T) 
 
 func newPrivateTransaction(value *big.Int, data []byte, key *ecdsa.PrivateKey) (*types.Transaction, *big.Int, common.Address) {
 	gasPrice := common.Big2
-
 	defaultTxPoolGasLimit := uint64(1000000)
 	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, value, defaultTxPoolGasLimit, gasPrice, data), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -301,7 +301,9 @@ func TestQuorumInvalidTransactions(t *testing.T) {
 	pool, key := setupQuorumTxPool()
 	defer pool.Stop()
 
-	tx := transaction(0, 0, key)
+	//tx := transaction(0, 0, key)
+	tx := transaction(0, 1000, key)
+
 	if err := pool.AddRemote(tx); err != ErrInvalidGasPrice {
 		t.Error("expected", ErrInvalidGasPrice, "; got", err)
 	}
@@ -312,7 +314,9 @@ func TestValidateTx_whenValueZeroTransferForPrivateTransaction(t *testing.T) {
 	pool, key := setupQuorumTxPool()
 	defer pool.Stop()
 	zeroValue := common.Big0
-	zeroGasPrice := common.Big0
+	//zeroGasPrice := common.Big0
+	zeroGasPrice := common.Big2
+
 	defaultTxPoolGasLimit := uint64(1000000)
 	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, zeroGasPrice, nil), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()
@@ -335,7 +339,9 @@ func TestValidateTx_whenValueNonZeroTransferForPrivateTransaction(t *testing.T) 
 }
 
 func newPrivateTransaction(value *big.Int, data []byte, key *ecdsa.PrivateKey) (*types.Transaction, *big.Int, common.Address) {
-	zeroGasPrice := common.Big0
+	//zeroGasPrice := common.Big0
+	zeroGasPrice := common.Big2
+
 	defaultTxPoolGasLimit := uint64(1000000)
 	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, value, defaultTxPoolGasLimit, zeroGasPrice, data), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -300,9 +300,9 @@ func TestValidateTx_whenValueZeroTransferForPrivateTransaction(t *testing.T) {
 	pool, key := setupQuorumTxPool()
 	defer pool.Stop()
 	zeroValue := common.Big0
-	gasPrice := common.Big2
+	zeroGasPrice := common.Big0
 	defaultTxPoolGasLimit := uint64(1000000)
-	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, gasPrice, nil), types.HomesteadSigner{}, key)
+	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, zeroGasPrice, nil), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()
 
 	if err := pool.AddRemote(arbitraryTx); err != ErrEtherValueUnsupported {
@@ -323,9 +323,9 @@ func TestValidateTx_whenValueNonZeroTransferForPrivateTransaction(t *testing.T) 
 }
 
 func newPrivateTransaction(value *big.Int, data []byte, key *ecdsa.PrivateKey) (*types.Transaction, *big.Int, common.Address) {
-	gasPrice := common.Big2
+	zeroGasPrice := common.Big0
 	defaultTxPoolGasLimit := uint64(1000000)
-	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, value, defaultTxPoolGasLimit, gasPrice, data), types.HomesteadSigner{}, key)
+	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, value, defaultTxPoolGasLimit, zeroGasPrice, data), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()
 	balance := new(big.Int).Add(arbitraryTx.Value(), new(big.Int).Mul(new(big.Int).SetUint64(arbitraryTx.Gas()), arbitraryTx.GasPrice()))
 	from, _ := deriveSender(arbitraryTx)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -300,7 +300,6 @@ func TestValidateTx_whenValueZeroTransferForPrivateTransaction(t *testing.T) {
 	pool, key := setupQuorumTxPool()
 	defer pool.Stop()
 	zeroValue := common.Big0
-	//zeroGasPrice := common.Big0
 	gasPrice := common.Big2
 
 	defaultTxPoolGasLimit := uint64(1000000)
@@ -325,7 +324,6 @@ func TestValidateTx_whenValueNonZeroTransferForPrivateTransaction(t *testing.T) 
 }
 
 func newPrivateTransaction(value *big.Int, data []byte, key *ecdsa.PrivateKey) (*types.Transaction, *big.Int, common.Address) {
-	//zeroGasPrice := common.Big0
 	gasPrice := common.Big2
 
 	defaultTxPoolGasLimit := uint64(1000000)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -296,29 +296,15 @@ func TestInvalidTransactions(t *testing.T) {
 	}
 }
 
-//Test for transactions that are only invalid on Quorum
-func TestQuorumInvalidTransactions(t *testing.T) {
-	pool, key := setupQuorumTxPool()
-	defer pool.Stop()
-
-	//tx := transaction(0, 0, key)
-	tx := transaction(0, 1000, key)
-
-	if err := pool.AddRemote(tx); err != ErrInvalidGasPrice {
-		t.Error("expected", ErrInvalidGasPrice, "; got", err)
-	}
-
-}
-
 func TestValidateTx_whenValueZeroTransferForPrivateTransaction(t *testing.T) {
 	pool, key := setupQuorumTxPool()
 	defer pool.Stop()
 	zeroValue := common.Big0
 	//zeroGasPrice := common.Big0
-	zeroGasPrice := common.Big2
+	gasPrice := common.Big2
 
 	defaultTxPoolGasLimit := uint64(1000000)
-	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, zeroGasPrice, nil), types.HomesteadSigner{}, key)
+	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, zeroValue, defaultTxPoolGasLimit, gasPrice, nil), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()
 
 	if err := pool.AddRemote(arbitraryTx); err != ErrEtherValueUnsupported {
@@ -340,10 +326,10 @@ func TestValidateTx_whenValueNonZeroTransferForPrivateTransaction(t *testing.T) 
 
 func newPrivateTransaction(value *big.Int, data []byte, key *ecdsa.PrivateKey) (*types.Transaction, *big.Int, common.Address) {
 	//zeroGasPrice := common.Big0
-	zeroGasPrice := common.Big2
+	gasPrice := common.Big2
 
 	defaultTxPoolGasLimit := uint64(1000000)
-	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, value, defaultTxPoolGasLimit, zeroGasPrice, data), types.HomesteadSigner{}, key)
+	arbitraryTx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, value, defaultTxPoolGasLimit, gasPrice, data), types.HomesteadSigner{}, key)
 	arbitraryTx.SetPrivate()
 	balance := new(big.Int).Add(arbitraryTx.Value(), new(big.Int).Mul(new(big.Int).SetUint64(arbitraryTx.Gas()), arbitraryTx.GasPrice()))
 	from, _ := deriveSender(arbitraryTx)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -205,7 +205,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		evm.StateDB.CreateAccount(addr)
 	}
 	if evm.ChainConfig().IsQuorum {
-		// skip transfer if value /= 0 (see note: Quorum, States, and Value Transfer)
+		// skip transfer if value == 0 (see note: Quorum, States, and Value Transfer)
 		if value.Sign() != 0 {
 			if evm.quorumReadOnly {
 				return nil, gas, ErrReadOnlyValueTransfer
@@ -414,7 +414,7 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 		evm.StateDB.SetNonce(contractAddr, 1)
 	}
 	if evm.ChainConfig().IsQuorum {
-		// skip transfer if value /= 0 (see note: Quorum, States, and Value Transfer)
+		// skip transfer if value == 0 (see note: Quorum, States, and Value Transfer)
 		if value.Sign() != 0 {
 			if evm.quorumReadOnly {
 				return nil, common.Address{}, gas, ErrReadOnlyValueTransfer

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -229,11 +229,8 @@ func (b *EthAPIBackend) ProtocolVersion() int {
 }
 
 func (b *EthAPIBackend) SuggestPrice(ctx context.Context) (*big.Int, error) {
-	if b.ChainConfig().IsQuorum {
-		return big.NewInt(0), nil
-	} else {
-		return b.gpo.SuggestPrice(ctx)
-	}
+	// NOTE(joel): this was set to 0 in the previous version of Quorum
+	return b.gpo.SuggestPrice(ctx)
 }
 
 func (b *EthAPIBackend) ChainDb() ethdb.Database {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -677,6 +677,8 @@ func (s *PublicBlockChainAPI) doCall(ctx context.Context, args CallArgs, blockNr
 		gas = math.MaxUint64 / 2
 	}
 
+	// NOTE(joel): let's keep the default gas price 0 for now, but note this as a
+	// spot that might be tweaked in the future.
 	if gasPrice.Sign() == 0 && !s.b.ChainConfig().IsQuorum {
 		gasPrice = new(big.Int).SetUint64(defaultGasPrice)
 	}

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -517,8 +517,11 @@ func TestTransactionStatusLes2(t *testing.T) {
 	signer := types.HomesteadSigner{}
 
 	// test error status by sending an underpriced transaction
-	tx0, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
-	test(tx0, true, txStatus{Status: core.TxStatusUnknown, Error: core.ErrUnderpriced.Error()})
+	// aroommen. delete comments later
+	//TxGas                 uint64 = 21000 // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
+	// NIL gasPrice is being set
+	//tx0, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
+	//test(tx0, true, txStatus{Status: core.TxStatusUnknown, Error: core.ErrUnderpriced.Error()})
 
 	tx1, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, testBankKey)
 	test(tx1, false, txStatus{Status: core.TxStatusUnknown}) // query before sending, should be unknown

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -516,13 +516,6 @@ func TestTransactionStatusLes2(t *testing.T) {
 
 	signer := types.HomesteadSigner{}
 
-	// test error status by sending an underpriced transaction
-	// aroommen. delete comments later
-	//TxGas                 uint64 = 21000 // Per transaction not creating a contract. NOTE: Not payable on data of calls between transactions.
-	// NIL gasPrice is being set
-	//tx0, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, nil, nil), signer, testBankKey)
-	//test(tx0, true, txStatus{Status: core.TxStatusUnknown, Error: core.ErrUnderpriced.Error()})
-
 	tx1, _ := types.SignTx(types.NewTransaction(0, acc1Addr, big.NewInt(10000), params.TxGas, big.NewInt(100000000000), nil), signer, testBankKey)
 	test(tx1, false, txStatus{Status: core.TxStatusUnknown}) // query before sending, should be unknown
 	test(tx1, true, txStatus{Status: core.TxStatusPending})  // send valid processable tx, should return pending


### PR DESCRIPTION
The changes here allow users to specify a non-zero gas price for Quorum transactions. Previously Quorum only worked with a zero gas price. This is useful to enable network metering especially in consortium projects where the network enablers can be compensated for their costs. It's backward compatible in that the gas price can still be zero. 
@fixanoid  @joelburget I have incorporated code changes from the below pull request 
https://github.com/jpmorganchase/quorum/pull/288


