### PR TITLE
EstimateGas to handle private transaction gas cost differences

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -783,10 +783,6 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (h
 	//still run
 	//This makes the return value a potential over-estimate of gas, rather than the exact cost to run right now
 
-	//There is still one edge case: if the transaction has a low intrinsic gas cost, but a high execution cost, then
-	//it the addition of the extra gas needed to make it private may push it over the maximum gas allowed, but this
-	//wouldn't matter since we weren't planning to make it private
-
 	//if the transaction has a value then it cannot be private, so we can skip this check
 	if args.Value.ToInt().Cmp(big.NewInt(0)) == 0 {
 
@@ -796,7 +792,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args CallArgs) (h
 
 		if intrinsicGasPrivate > intrinsicGasPublic {
 			if math.MaxUint64 - hi < intrinsicGasPrivate - intrinsicGasPublic {
-				return 0, fmt.Errorf("gas required exceeds allowance or always failing transaction")
+				return 0, fmt.Errorf("private intrinsic gas addition exceeds allowance")
 			}
 			return hexutil.Uint64(hi + (intrinsicGasPrivate - intrinsicGasPublic)), nil
 		}


### PR DESCRIPTION
Compare intrinsic gas of public transaction versus the private version that contains the PTM hash instead. If there is a difference, add it on to the execution cost.

Consider the `SimpleStorage` contract:
```
pragma solidity ^0.5.0;

contract SimpleStorage {
    uint private storedData;

    constructor(uint initVal) public {
        storedData = initVal;
    }

    function set(uint x) public {
        storedData = x;
    }

    function get() public view returns (uint retVal) {
        return storedData;
    }
}
```

Calling the `set` function with the value `1989` produces the `data` field `60fe47b100000000000000000000000000000000000000000000000000000000000007c5`.

This is 36 bytes long, and consists of a lot of `0`'s (which have a lower gas cost). The intrinsic gas value of the transaction is `21528`.

If this were to be sent as a private transaction, this `data` field would be replaced by the hash the Private Transaction Manager produces, which is 64 bytes long, potentially with no `0`'s. Assuming the worst case hash with no `0`'s, the intrinsic gas cost of the transaction becomes `25352`.

If we were to use the original gas estimate and send it as a private transaction, it would fail with a `not enough gas` error.

Since the execution cost of the transaction would not change whether it becomes a public or private transaction, the only difference in gas required comes from the intrinsic gas cost. 

This PR adds on the difference between the intrinsic gas costs if the private cost is higher than the public cost. This changes the semantics of the call somewhat from "this is the exact gas cost right now" to "this is the maximum gas cost right now".