### PR TITLE
Use solc 0.5.4 when running acceptance tests against pull requests

### DIFF
--- a/build/travis-install-linux.sh
+++ b/build/travis-install-linux.sh
@@ -18,6 +18,7 @@ jdk_switcher use openjdk8
 java -version
 mvn --version
 sudo wget https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux -O /usr/local/bin/solc
+sudo chmod +x /usr/local/bin/solc
 solc --version
 echo "---> tools installation done"
 

--- a/build/travis-install-linux.sh
+++ b/build/travis-install-linux.sh
@@ -17,9 +17,7 @@ fi
 jdk_switcher use openjdk8
 java -version
 mvn --version
-sudo add-apt-repository -y ppa:ethereum/ethereum
-sudo apt update
-sudo apt-get -y install solc
+sudo wget https://github.com/ethereum/solidity/releases/download/v0.5.4/solc-static-linux -O /usr/local/bin/solc
 solc --version
 echo "---> tools installation done"
 


### PR DESCRIPTION
`solc 0.5.4` is the latest version that is compatible with current `geth 1.8.12`