### PR TITLE
Adding a node only if it is not in the raft peer list

### DIFF
--- a/raft/handler.go
+++ b/raft/handler.go
@@ -754,7 +754,7 @@ func (pm *ProtocolManager) eventLoop() {
 					case raftpb.ConfChangeAddNode:
 						if pm.isRaftIdRemoved(raftId) {
 							log.Info("ignoring ConfChangeAddNode for permanently-removed peer", "raft id", raftId)
-						} else if raftId <= uint16(len(pm.bootstrapNodes)) {
+						} else if peer := pm.peers[raftId]; peer != nil && raftId <= uint16(len(pm.bootstrapNodes))  {
 							// See initial cluster logic in startRaft() for more information.
 							log.Info("ignoring expected ConfChangeAddNode for initial peer", "raft id", raftId)
 


### PR DESCRIPTION
There is a panic and the raft node crashes if `static-nodes.json` is updated first and then the node is added by calling  `raft.addPeer()`. The fix checks if peer exists, if it does not then it adds the peer and forces a snapshot, which was failing earlier.

Fixes #642 