### PR TITLE
ETHAPI: Private tx bug fixes for Sign and Send APIs

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -398,7 +398,7 @@ func (s *PrivateAccountAPI) SendTransaction(ctx context.Context, args SendTxArgs
 		data := []byte(*args.Data)
 		if len(data) > 0 {
 			log.Info("sending private tx", "data", fmt.Sprintf("%x", data), "privatefrom", args.PrivateFrom, "privatefor", args.PrivateFor)
-			data, err := private.P.Send(data, args.PrivateFrom, args.PrivateFor)
+			data, err = private.P.Send(data, args.PrivateFrom, args.PrivateFor)
 			log.Info("sent private tx", "data", fmt.Sprintf("%x", data), "privatefrom", args.PrivateFrom, "privatefor", args.PrivateFor)
 			if err != nil {
 				return common.Hash{}, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -366,10 +366,12 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args *SendTxArg
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
 
-	isPrivate := args.PrivateFor != nil
+	if len(args.PrivateFor) > 0 {
+		tx.SetPrivate()
+	}
 
 	var chainID *big.Int
-	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) && !isPrivate {
+	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) && !tx.IsPrivate() {
 		chainID = config.ChainID
 	}
 	return wallet.SignTxWithPassphrase(account, passwd, tx, chainID)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1512,9 +1512,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if err != nil {
 		return nil, err
 	}
-	if args.PrivateFor != nil {
-		tx.SetPrivate()
-	}
+
 	data, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		return nil, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1500,7 +1500,13 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return nil, err
 	}
-	tx, err := s.sign(args.From, args.toTransaction())
+
+	toSign := args.toTransaction()
+	if len(args.PrivateFor) > 0 {
+		toSign.SetPrivate()
+	}
+
+	tx, err := s.sign(args.From, toSign)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -366,7 +366,7 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args *SendTxArg
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
 
-	if len(args.PrivateFor) > 0 {
+	if args.PrivateFor != nil {
 		tx.SetPrivate()
 	}
 
@@ -1504,7 +1504,7 @@ func (s *PublicTransactionPoolAPI) SignTransaction(ctx context.Context, args Sen
 	}
 
 	toSign := args.toTransaction()
-	if len(args.PrivateFor) > 0 {
+	if args.PrivateFor != nil {
 		toSign.SetPrivate()
 	}
 
@@ -1578,7 +1578,7 @@ func (s *PublicTransactionPoolAPI) Resend(ctx context.Context, sendArgs SendTxAr
 				sendArgs.Gas = gasLimit
 			}
 			newTx := sendArgs.toTransaction()
-			if len(sendArgs.PrivateFor) > 0 {
+			if sendArgs.PrivateFor != nil {
 				newTx.SetPrivate()
 			}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -366,8 +366,10 @@ func (s *PrivateAccountAPI) signTransaction(ctx context.Context, args *SendTxArg
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
 
+	isPrivate := args.PrivateFor != nil
+
 	var chainID *big.Int
-	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
+	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) && !isPrivate {
 		chainID = config.ChainID
 	}
 	return wallet.SignTxWithPassphrase(account, passwd, tx, chainID)


### PR DESCRIPTION
This PR addresses bugs when using 3 of the sign and send API endpoints with private transactions:

1. `personal_signTransaction`
   **Bug**: Private txs signed using this endpoint are not minted into a block when submitted.
   Currently the tx is not checked to be private and so is always signed using the EIP155 signer (i.e. the signature includes the `chainID`).  When submitting the tx (e.g. with `eth_sendRawPrivateTransaction`) if the tx is private the signature is validated using the Homestead signer (i.e. assumes the signature does not include the `chainID`).  
   
    **Fix**: Check the tx is private before setting the `chainID`.  Set the `v` value to `37/38` so that the resulting signed tx has the correct `v` value.  This ensures it is signed with the Homestead signer.

2. `personal_sendTransaction`
   Fixes #677 

3. `eth_signTransaction`
   **Bug**: Private txs signed using this endpoint are not minted into a block when submitted.
   Similar to the `personal_signTransaction` bug, the signing component of this method is unable to determine whether the tx is private and so always uses the EIP155 signer.  

   **Fix**: Set the `v` of the private tx to `37/38` before the signing to ensure it is signed using the Homestead signer