### PR TITLE
 Added web3_eccKeyPair, web3_eciesEnc, web3_eciesDec for the rpc api

### DIFF
--- a/crypto/ecies/params.go
+++ b/crypto/ecies/params.go
@@ -39,6 +39,7 @@ import (
 	"crypto/elliptic"
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/ecdsa"
 	"fmt"
 	"hash"
 
@@ -114,4 +115,12 @@ func AddParamsForCurve(curve elliptic.Curve, params *ECIESParams) {
 // Only the curves P256, P384, and P512 are supported.
 func ParamsFromCurve(curve elliptic.Curve) (params *ECIESParams) {
 	return paramsFromCurve[curve]
+}
+
+func HexToECDSA(prv string) (*ecdsa.PrivateKey, error) {
+	return ethcrypto.HexToECDSA(prv)
+}
+
+func ToECDSA(prv []byte)(*ecdsa.PrivateKey, error) {
+	return ethcrypto.ToECDSA(prv)
 }

--- a/node/api.go
+++ b/node/api.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -461,4 +462,25 @@ func (s *PublicWeb3API) ClientVersion() string {
 // It assumes the input is hex encoded.
 func (s *PublicWeb3API) Sha3(input hexutil.Bytes) hexutil.Bytes {
 	return crypto.Keccak256(input)
+}
+
+// ECIESENC applies the ethereum ECIES encryption.
+// It assumes all inputs are hex encoded.
+func (s *PublicWeb3API) EciesEnc(priv, pub, input hexutil.Bytes) (hexutil.Bytes, error) {
+	return ecies.Web3ECIESENC(priv, pub, input)
+}
+
+// ECIESDEC applies the ethereum ECIES decryption.
+// It assumes all inputs are hex encoded.
+func (s *PublicWeb3API) EciesDec(priv, input hexutil.Bytes) (hexutil.Bytes, error) {
+	return ecies.Web3ECIESDEC(priv, input)
+}
+
+// Generates a ECC Key Pair
+func (s *PublicWeb3API) EccKeyPair() interface{} {
+	priv, pub := ecies.EccKeyPairHex()
+	return map[string]interface{}{
+     "privatekey": priv,
+     "publickey": pub,
+	}
 }


### PR DESCRIPTION
Method `web3_eccKeyPair` generates a ECC key pair

```
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_eccKeyPair","params":[],"id":1}' 
```

 `web3_eccKeyPair` Result:
```
{
	"jsonrpc": "2.0",
	"id": 1,
	"result": {
		"privatekey": "5885d70ca0b07b1584b0cb414541ec3bc1ae10fffc7b29c6e55f59d15891a96d",
		"publickey": "0447392493f742001d3b0f405733cfa33aebb3ad2ca04035d77de13ef89f8adb69733c50e36d95d922f52e75e9c8f58bc498eedf190adfbfabb121281a0cf054b8"
	}
}
```
Method `web3_eciesEnc` encrypts with ECIES (Elliptic Curve Integrated Encryption Scheme) a content using sender private key and receiver public key generated from `web3_eccKeyPair`

```
curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_eciesEnc","params":["0x5885d70ca0b07b1584b0cb414541ec3bc1ae10fffc7b29c6e55f59d15891a96d", "0x045c2b32c354cfdef043e48b1f4f80ac9bd3e26385adf52d26047c23c8a575e6c884610797c7774ef79a43bd01d330f70b2113520a07636cb9903e4b42ee0da3eb", "0x68656c6c6f20626f622069747320616c696365"],"id":1}' 
```
`web3_eciesEnc` Result:
```
{
	"jsonrpc": "2.0",
	"id": 1,
	"result": "0x0447392493f742001d3b0f405733cfa33aebb3ad2ca04035d77de13ef89f8adb69733c50e36d95d922f52e75e9c8f58bc498eedf190adfbfabb121281a0cf054b83dfd1ebf1b6af9ec33ab8791bf88c56f5e3e58ef45ca5e7a8cb8fade6b92cf04df7f34af052bd540136ab72f03f7ce09aafebdb36cc6ec9e3843adce697190e844e14a"
}
```

Method `web3_eciesDec` decrypts with ECIES (Elliptic Curve Integrated Encryption Scheme) a content using receiver private key generated from `web3_eccKeyPair`

```
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_eciesDec","params":["0x20d167c1638132a0935e010199716a7afddc1e3288985c54b17b93b7adb39c94", "0x0447392493f742001d3b0f405733cfa33aebb3ad2ca04035d77de13ef89f8adb69733c50e36d95d922f52e75e9c8f58bc498eedf190adfbfabb121281a0cf054b81f9392b52240cca478a6850301c03b63e7e5eb6ef2706b1c89ba3cd2ba3ba7c3dccd00fd35c4e9b032951fba3093f03b382734364881f5aea5851ef9aae6bca1580ddb"],"id":1}'
```

`web3_eciesDec` Result:

```
{
	"jsonrpc": "2.0",
	"id": 1,
	"result": "0x68656c6c6f20626f622069747320616c696365"
}
```

I will add `eciesEnc` and `eciesDec` functionality for the EVM and solidity compiler in the future
