### PR TITLE
p2p/simulations: Enable access to MsgEvents with execadapter

### DIFF
--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -102,7 +102,7 @@ func (e *ExecAdapter) NewNode(config *NodeConfig) (Node, error) {
 	conf.Stack.WSPort = 0
 	conf.Stack.WSOrigins = []string{"*"}
 	conf.Stack.WSExposeAll = true
-	conf.Stack.P2P.EnableMsgEvents = false
+	conf.Stack.P2P.EnableMsgEvents = config.EnableMsgEvents
 	conf.Stack.P2P.NoDiscovery = true
 	conf.Stack.P2P.NAT = nil
 	conf.Stack.NoUSB = true


### PR DESCRIPTION
`EnableMsgEvents` options for p2p config are currently hardcoded for `ExecAdapter`. This is change is required to be able to enable it using the `adapters.NodeConfig` directive.