### PR TITLE
internal/ethapi: ask transaction pool for pending nonce

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1156,7 +1156,6 @@ func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, addr
 		if err != nil {
 			return nil, err
 		}
-		log.Info("AJ-pending block number ", "nonce", nonce)
 		return (*hexutil.Uint64)(&nonce), nil
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1150,6 +1150,17 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByBlockHashAndIndex(ctx cont
 
 // GetTransactionCount returns the number of transactions the given address has sent for the given block number
 func (s *PublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
+	// Ask transaction pool for the nonce which includes pending transactions
+	if blockNr == rpc.PendingBlockNumber {
+		nonce, err := s.b.GetPoolNonce(ctx, address)
+		if err != nil {
+			return nil, err
+		}
+		log.Info("AJ-pending block number ", "nonce", nonce)
+		return (*hexutil.Uint64)(&nonce), nil
+	}
+
+	// Resolve block number and use its state to ask for the nonce
 	state, _, err := s.b.StateAndHeaderByNumber(ctx, blockNr)
 	if state == nil || err != nil {
 		return nil, err


### PR DESCRIPTION
currently tx count is not getting incremented for pending transactions when giving second argument of 'pending'. It seems to be treated the same as 'latest'. This change fixes this issue.

this has been fixed in ethereum https://github.com/ethereum/go-ethereum/pull/15794
