### PR TITLE
max code size option in genesis config

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -384,7 +384,7 @@ func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 			common.BytesToAddress([]byte{6}): {Balance: big.NewInt(1)}, // ECAdd
 			common.BytesToAddress([]byte{7}): {Balance: big.NewInt(1)}, // ECScalarMul
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
-			faucet: {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
+			faucet:                           {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
 		},
 	}
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -169,8 +169,13 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 		if genesis.Config.TransactionSizeLimit == 0 {
 			genesis.Config.TransactionSizeLimit = DefaultTxPoolConfig.TransactionSizeLimit
 		}
+		// Set default contract size limit that can be deployed if not set in genesis
+		if genesis.Config.MaxCodeSize == 0 {
+			genesis.Config.MaxCodeSize = DefaultTxPoolConfig.MaxCodeSize
+		}
 
-		// Check transaction size limit
+
+		// Check transaction size limit and max contract code size
 		err := genesis.Config.IsValid()
 		if err != nil {
 			return genesis.Config, common.Hash{}, err

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -174,7 +174,6 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 			genesis.Config.MaxCodeSize = DefaultTxPoolConfig.MaxCodeSize
 		}
 
-
 		// Check transaction size limit and max contract code size
 		err := genesis.Config.IsValid()
 		if err != nil {
@@ -385,7 +384,7 @@ func DeveloperGenesisBlock(period uint64, faucet common.Address) *Genesis {
 			common.BytesToAddress([]byte{6}): {Balance: big.NewInt(1)}, // ECAdd
 			common.BytesToAddress([]byte{7}): {Balance: big.NewInt(1)}, // ECScalarMul
 			common.BytesToAddress([]byte{8}): {Balance: big.NewInt(1)}, // ECPairing
-			faucet:                           {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
+			faucet: {Balance: new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(9))},
 		},
 	}
 }

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -104,7 +104,7 @@ func TestSetupGenesis(t *testing.T) {
 			wantErr:    errors.New("Genesis max code size must be between 24 and 128"),
 			wantConfig: customg.Config,
 		},
-		
+
 		// {
 		// 	name: "custom block in DB, genesis == nil",
 		// 	fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -95,6 +95,16 @@ func TestSetupGenesis(t *testing.T) {
 			wantErr:    errors.New("Genesis transaction size limit must be between 32 and 128"),
 			wantConfig: customg.Config,
 		},
+		{
+			name: "genesis with incorrect max code size ",
+			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
+				customg.Config.MaxCodeSize = 100000
+				return SetupGenesisBlock(db, &customg)
+			},
+			wantErr:    errors.New("Genesis max code size must be between 24 and 128"),
+			wantConfig: customg.Config,
+		},
+		
 		// {
 		// 	name: "custom block in DB, genesis == nil",
 		// 	fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -90,6 +90,7 @@ func TestSetupGenesis(t *testing.T) {
 			name: "genesis with incorrect SizeLimit",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
 				customg.Config.TransactionSizeLimit = 100000
+				customg.Config.MaxCodeSize = 32
 				return SetupGenesisBlock(db, &customg)
 			},
 			wantErr:    errors.New("Genesis transaction size limit must be between 32 and 128"),
@@ -98,6 +99,7 @@ func TestSetupGenesis(t *testing.T) {
 		{
 			name: "genesis with incorrect max code size ",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
+				customg.Config.TransactionSizeLimit = 64
 				customg.Config.MaxCodeSize = 100000
 				return SetupGenesisBlock(db, &customg)
 			},

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -135,7 +135,7 @@ type TxPoolConfig struct {
 	Rejournal time.Duration    // Time interval to regenerate the local transaction journal
 
 	TransactionSizeLimit uint64 // Maximum size allowed for valid transaction (in KB)
-	MaxCodeSize uint64 // Maximum size allowed of contract code that can be deployed (in KB)
+	MaxCodeSize          uint64 // Maximum size allowed of contract code that can be deployed (in KB)
 
 	PriceLimit uint64 // Minimum gas price to enforce for acceptance into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
@@ -155,7 +155,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Rejournal: time.Hour,
 
 	TransactionSizeLimit: 64,
-	MaxCodeSize: 24,
+	MaxCodeSize:          24,
 
 	PriceLimit: 1,
 	PriceBump:  10,

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -135,6 +135,7 @@ type TxPoolConfig struct {
 	Rejournal time.Duration    // Time interval to regenerate the local transaction journal
 
 	TransactionSizeLimit uint64 // Maximum size allowed for valid transaction (in KB)
+	MaxCodeSize uint64 // Maximum size allowed of contract code that can be deployed (in KB)
 
 	PriceLimit uint64 // Minimum gas price to enforce for acceptance into the pool
 	PriceBump  uint64 // Minimum price bump percentage to replace an already existing transaction (nonce)
@@ -154,6 +155,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Rejournal: time.Hour,
 
 	TransactionSizeLimit: 64,
+	MaxCodeSize: 24,
 
 	PriceLimit: 1,
 	PriceBump:  10,

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -487,9 +487,16 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	ret, err := run(evm, contract, nil, false)
 
+	var maxCodeSize int
+	if evm.ChainConfig().MaxCodeSize > 0 {
+		maxCodeSize = int(evm.ChainConfig().MaxCodeSize * 1024)
+	} else {
+		maxCodeSize = params.MaxCodeSize
+	}
+
 	// check whether the max code size has been exceeded, check maxcode size from chain config
 	// maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > params.MaxCodeSize
-	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && float64(len(ret)) > float64((evm.ChainConfig().MaxCodeSize*1024))
+	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > maxCodeSize
 	// if the contract creation ran successfully and no errors were returned
 	// calculate the gas required to store the code. If the code could not
 	// be stored due to not enough gas set an error and let it be handled

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -488,8 +488,8 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	ret, err := run(evm, contract, nil, false)
 
 	// check whether the max code size has been exceeded, check maxcode size from chain config
-	// maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > params.MaxCodeSize	
-	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && float64(len(ret)) > float64((evm.ChainConfig().MaxCodeSize * 1024))
+	// maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > params.MaxCodeSize
+	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && float64(len(ret)) > float64((evm.ChainConfig().MaxCodeSize*1024))
 	// if the contract creation ran successfully and no errors were returned
 	// calculate the gas required to store the code. If the code could not
 	// be stored due to not enough gas set an error and let it be handled

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -487,8 +487,9 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	ret, err := run(evm, contract, nil, false)
 
-	// check whether the max code size has been exceeded
-	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > params.MaxCodeSize
+	// check whether the max code size has been exceeded, check maxcode size from chain config
+	// maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && len(ret) > params.MaxCodeSize	
+	maxCodeSizeExceeded := evm.ChainConfig().IsEIP158(evm.BlockNumber) && float64(len(ret)) > float64((evm.ChainConfig().MaxCodeSize * 1024))
 	// if the contract creation ran successfully and no errors were returned
 	// calculate the gas required to store the code. If the code could not
 	// be stored due to not enough gas set an error and let it be handled

--- a/params/config.go
+++ b/params/config.go
@@ -132,7 +132,7 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32,32}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32, 32}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
@@ -141,10 +141,10 @@ var (
 	// adding flags to the config to also have to set these fields.
 	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, false, 32, 32}
 
-	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32,32}
+	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32, 32}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 
-	QuorumTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, nil, common.Hash{}, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64,32}
+	QuorumTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, nil, common.Hash{}, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64, 32}
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
@@ -190,7 +190,7 @@ type ChainConfig struct {
 
 	IsQuorum             bool   `json:"isQuorum"`
 	TransactionSizeLimit uint64 `json:"txnSizeLimit"`
-	MaxCodeSize					 uint64 `json:"maxCodeSize"`
+	MaxCodeSize          uint64 `json:"maxCodeSize"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -251,8 +251,8 @@ func (c *ChainConfig) String() string {
 	)
 }
 
-func (c *ChainConfig) IsValid() error {	
-	
+func (c *ChainConfig) IsValid() error {
+
 	if c.TransactionSizeLimit < 32 || c.TransactionSizeLimit > 128 {
 		return errors.New("Genesis transaction size limit must be between 32 and 128")
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -132,19 +132,19 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32,32}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, false, 32}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, false, 32, 32}
 
-	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32}
+	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32,32}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 
-	QuorumTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, nil, common.Hash{}, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64}
+	QuorumTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, nil, common.Hash{}, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64,32}
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
@@ -190,6 +190,7 @@ type ChainConfig struct {
 
 	IsQuorum             bool   `json:"isQuorum"`
 	TransactionSizeLimit uint64 `json:"txnSizeLimit"`
+	MaxCodeSize					 uint64 `json:"maxCodeSize"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -250,9 +251,14 @@ func (c *ChainConfig) String() string {
 	)
 }
 
-func (c *ChainConfig) IsValid() error {
+func (c *ChainConfig) IsValid() error {	
+	
 	if c.TransactionSizeLimit < 32 || c.TransactionSizeLimit > 128 {
 		return errors.New("Genesis transaction size limit must be between 32 and 128")
+	}
+
+	if c.MaxCodeSize < 24 || c.MaxCodeSize > 128 {
+		return errors.New("Genesis max code size must be between 24 and 128")
 	}
 
 	return nil


### PR DESCRIPTION
fixes issue #324 - 
added new config option in genesis file for maxCodeSize (in KB) that can be deployed. Default is 24 kb , similar to ethereum, and max is 128 kb (txnSizeLimit)

add the following in config to deploy large contracts. 
"maxCodeSize": 64
