### PR TITLE
Allow to use hostname in enode (static-nodes.json)

### DIFF
--- a/p2p/discv5/node.go
+++ b/p2p/discv5/node.go
@@ -138,7 +138,7 @@ var incompleteNodeURL = regexp.MustCompile("(?i)^(?:enode://)?([0-9a-f]+)$")
 //
 // For complete nodes, the node ID is encoded in the username portion
 // of the URL, separated from the host by an @ sign. The hostname can
-// only be given as an IP address, DNS domain names are not allowed.
+// be given as an IP address or DNS domain.
 // The port in the host name section is the TCP listening port. If the
 // TCP and UDP (discovery) ports differ, the UDP port is specified as
 // query parameter "discport".
@@ -185,7 +185,13 @@ func parseComplete(rawurl string) (*Node, error) {
 		return nil, fmt.Errorf("invalid host: %v", err)
 	}
 	if ip = net.ParseIP(host); ip == nil {
-		return nil, errors.New("invalid IP address")
+		// attempt to look up IP addresses if host is a FQDN
+		lookupIPs, err := net.LookupIP(host)
+		if err != nil {
+			return nil, errors.New("invalid IP address")
+		}
+		// set to first ip by default
+		ip = lookupIPs[0]
 	}
 	// Ensure the IP is 4 bytes long for IPv4 addresses.
 	if ipv4 := ip.To4(); ipv4 != nil {

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -67,7 +67,7 @@ var parseNodeTests = []struct {
 	},
 	// Complete nodes with IP address.
 	{
-		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname:3",
+		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname!:3",
 		wantError: `invalid IP address`,
 	},
 	{

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -56,7 +56,7 @@ func MustParseV4(rawurl string) *Node {
 //
 // For complete nodes, the node ID is encoded in the username portion
 // of the URL, separated from the host by an @ sign. The hostname can
-// only be given as an IP address, DNS domain names are not allowed.
+// be given as an IP address or DNS domain.
 // The port in the host name section is the TCP listening port. If the
 // TCP and UDP (discovery) ports differ, the UDP port is specified as
 // query parameter "discport".
@@ -129,8 +129,15 @@ func parseComplete(rawurl string) (*Node, error) {
 		return nil, fmt.Errorf("invalid host: %v", err)
 	}
 	if ip = net.ParseIP(host); ip == nil {
-		return nil, errors.New("invalid IP address")
+		// attempt to look up IP addresses if host is a FQDN
+		lookupIPs, err := net.LookupIP(host)
+		if err != nil {
+			return nil, errors.New("invalid IP address")
+		}
+		// set to first ip by default
+		ip = lookupIPs[0]
 	}
+
 	// Ensure the IP is 4 bytes long for IPv4 addresses.
 	if ipv4 := ip.To4(); ipv4 != nil {
 		ip = ipv4

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -42,7 +42,7 @@ var parseNodeTests = []struct {
 	},
 	// Complete nodes with IP address.
 	{
-		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname:3",
+		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@hostname!:3",
 		wantError: `invalid IP address`,
 	},
 	{


### PR DESCRIPTION
Close https://github.com/jpmorganchase/quorum/issues/147 

## Feature
Add ability to use `hostname` in enode  e.g. enode://...@hostname:30303?discport=0&raftport=50400
If host is not an IP uses `net.lookupIP` and use the first resolved IP.

This is a back port of https://github.com/jpmorganchase/quorum/commit/749acf065caea332e550bf31a918a8dab15f2908 that was introduced in https://github.com/jpmorganchase/quorum/issues/147 and lost after fcfc7b6d452fd9c42014c055dc9da39baf80e226 (merge with geth upstream).
