### PR TITLE
Fix incorrectly displayed CLI flags in geth usage

### DIFF
--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -272,13 +272,14 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
-		Name: "MISC",
-	},{
 		Name: "ISTANBUL",
 		Flags: []cli.Flag{
 			utils.IstanbulRequestTimeoutFlag,
 			utils.IstanbulBlockPeriodFlag,
 		},
+	},
+	{
+		Name: "MISC",
 	},
 }
 


### PR DESCRIPTION
Any flags not explicitly added to a flag group are appended to the last flag group defined. 

Define the MISC group after the ISTANBUL group so that generic flags (e.g. --emitcheckpoints, --help) are correctly displayed as MISC OPTIONS and not ISTANBUL OPTIONS in the geth usage.

`geth help` before
```
...

MISC OPTIONS:

ISTANBUL OPTIONS:
  --istanbul.requesttimeout value  Timeout for each Istanbul round in milliseconds (default: 10000)
  --istanbul.blockperiod value     Default minimum difference between two consecutive block's timestamps in seconds (default: 1)
  --emitcheckpoints                If enabled, emit specially formatted logging checkpoints
  --help, -h                       show help
```

`geth help` after 
```
...

ISTANBUL OPTIONS:
  --istanbul.requesttimeout value  Timeout for each Istanbul round in milliseconds (default: 10000)
  --istanbul.blockperiod value     Default minimum difference between two consecutive block's timestamps in seconds (default: 1)

MISC OPTIONS:
  --emitcheckpoints  If enabled, emit specially formatted logging checkpoints
  --help, -h         show help
```