### PR TITLE
Reorganize raft faq

### DIFF
--- a/docs/Consensus/raft.md
+++ b/docs/Consensus/raft.md
@@ -158,27 +158,4 @@ To add a node to the cluster, attach to a JS console and issue `raft.addPeer(eno
 
 ## FAQ
 
-**Could you have a single- or two-node cluster? More generally, could you have an even number of nodes ?**
-
-A cluster can tolerate failures that leave a quorum (majority) available. So a cluster of two nodes can't tolerate any failures, three nodes can tolerate one, and five nodes can tolerate two. Typically Raft clusters have an odd number of nodes, since an even number provides no failure tolerance benefit.
-
-**What happens if you don't assume minter and leader are the same node?**
-
-There's no hard reason they couldn't be different. We just co-locate the minter and leader as an optimization.
-
-* It saves one network call communicating the block to the leader.
-* It provides a simple way to choose a minter. If we didn't use the Raft leader we'd have to build in "minter election" at a higher level.
-
-Additionally there could even be multiple minters running at the same time, but this would produce contention for which blocks actually extend the chain, reducing the productivity of the cluster (see "races" above).
-
-**I thought there were no forks in a Raft-based blockchain. What's the deal with "speculative minting"?**
-
-"Speculative chains" are not forks in the blockchain. They represent a series ("chain") of blocks that have been sent through Raft, after which each of the blocks may or may not actually end up being included in *the blockchain*.
-
-**Can transactions be reversed? Since raft log entries can be disregarded as "no-ops", does this imply transaction reversal?**
-
-No. When a Raft log entry containing a new block is disregarded as a "no-op", its transactions will remain in the transaction pool, and so they will be included in a future block in the chain.
-
-**What's the deal with the block timestamp being stored in nanoseconds (instead of seconds, like other consensus mechanisms)?**
-
-With raft-based consensus we can produce far more than one block per second, which vanilla Ethereum implicitly disallows (as the default timestamp resolution is in seconds and every block must have a timestamp greater than its parent). For Raft, we store the timestamp in nanoseconds and ensure it is incremented by at least 1 nanosecond per block.
+Answers to frequently asked questions can be found on the main [Quorum FAQ page](../FAQ.md).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -71,8 +71,8 @@
 ??? question "What's the deal with the block timestamp being stored in nanoseconds (instead of seconds, like other consensus mechanisms)?"
     With raft-based consensus we can produce far more than one block per second, which vanilla Ethereum implicitly disallows (as the default timestamp resolution is in seconds and every block must have a timestamp greater than its parent). For Raft, we store the timestamp in nanoseconds and ensure it is incremented by at least 1 nanosecond per block.
 
-??? question "Why do I see "Error: Number can only safely store up to 53 bits" when using Web3 with Raft?"
-    As mentioned above, Raft stores the timestamp in nanoseconds, so it is too large to be retrieved as an 'int/uint'.
+??? question "Why do I see "Error: Number can only safely store up to 53 bits" when using web3js with Raft?"
+    As mentioned above, Raft stores the timestamp in nanoseconds, so it is too large to be held as a number in javascript.
     You need to modify your code to take account of this. An example can be seen [here](https://github.com/jpmorganchase/quorum.js/blob/master/lib/index.js#L35).
     A future quorum release will address this issue.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,5 @@
+### Quorum FAQ
+
 ??? question "I've run into an issue with Quorum, where do I get support?"
     The [Quorum Slack channels](https://clh7rniov2.execute-api.us-east-1.amazonaws.com/Express/) are the best place to query the community and get immediate help.
  
@@ -38,9 +40,6 @@
 ??? question "Can I create a network of Quorum nodes using different consensus mechanisms?"
     Unfortunately, that is not possible. Quorum nodes configured with raft will only be able to work correctly with other nodes running raft consensus. This applies to all other supported consensus algorithms.
 
-??? info "Known Raft consensus node misconfiguration"
-    Please see https://github.com/jpmorganchase/quorum/issues/410
-
 ??? info "Quorum version compatibility table"
     |                                     | Adding new node v2.0.x | Adding new node v2.1.x | Adding new node v2.2.x |
     | ----------------------------------- | ---------------------- | ---------------------- | ---------------------- |
@@ -49,3 +48,33 @@
     | Existing chain consisting of v2.2.x | <span style="color:red;">block sync</span>  | <span style="color:green;">block sync<br /> public txn<br /> private txn</span> | <span style="color:green;">block sync<br /> public txn<br /> private txn</span> |
 
     **Note:** While every Quorum v2 client will be able to connect to any other v2 client, the usefullness will be severely degraded. <span style="color:red;">Red color</span> signifies that while connectivity is possible, <span style="color:red;">red colored</span> versions will be unable to send public or private txns to the rest of the net due to the EIP155 changes in the signer implemented in newer versions.
+
+### Raft FAQ
+
+??? question "Could you have a single- or two-node cluster? More generally, could you have an even number of nodes?"
+    A cluster can tolerate failures that leave a quorum (majority) available. So a cluster of two nodes can't tolerate any failures, three nodes can tolerate one, and five nodes can tolerate two. Typically Raft clusters have an odd number of nodes, since an even number provides no failure tolerance benefit.
+
+??? question "What happens if you don't assume minter and leader are the same node?"
+    There's no hard reason they couldn't be different. We just co-locate the minter and leader as an optimization.
+    
+    * It saves one network call communicating the block to the leader.
+    * It provides a simple way to choose a minter. If we didn't use the Raft leader we'd have to build in "minter election" at a higher level.
+
+    Additionally there could even be multiple minters running at the same time, but this would produce contention for which blocks actually extend the chain, reducing the productivity of the cluster (see "races" above).
+
+??? question "I thought there were no forks in a Raft-based blockchain. What's the deal with "speculative minting"?"
+    "Speculative chains" are not forks in the blockchain. They represent a series ("chain") of blocks that have been sent through Raft, after which each of the blocks may or may not actually end up being included in *the blockchain*.
+
+??? question "Can transactions be reversed? Since raft log entries can be disregarded as "no-ops", does this imply transaction reversal?"
+    No. When a Raft log entry containing a new block is disregarded as a "no-op", its transactions will remain in the transaction pool, and so they will be included in a future block in the chain.
+
+??? question "What's the deal with the block timestamp being stored in nanoseconds (instead of seconds, like other consensus mechanisms)?"
+    With raft-based consensus we can produce far more than one block per second, which vanilla Ethereum implicitly disallows (as the default timestamp resolution is in seconds and every block must have a timestamp greater than its parent). For Raft, we store the timestamp in nanoseconds and ensure it is incremented by at least 1 nanosecond per block.
+
+??? question "Why do I see "Error: Number can only safely store up to 53 bits" when using Web3 with Raft?"
+    As mentioned above, Raft stores the timestamp in nanoseconds, so it is too large to be retrieved as an 'int/uint'.
+    You need to modify your code to take account of this. An example can be seen [here](https://github.com/jpmorganchase/quorum.js/blob/master/lib/index.js#L35).
+    A future quorum release will address this issue.
+
+??? info "Known Raft consensus node misconfiguration"
+    Please see https://github.com/jpmorganchase/quorum/issues/410


### PR DESCRIPTION
Moving the Raft FAQ into the main FAQ section, so that the FAQ's are in the same place.
Also added explanation of "Error: Number can only safely store up to 53 bits" issue.