### PR TITLE
Issue 802 fix raft hangup when isQuorum false

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -212,7 +212,7 @@ func newWorker(config *params.ChainConfig, engine consensus.Engine, eth Backend,
 		resubmitIntervalCh: make(chan time.Duration),
 		resubmitAdjustCh:   make(chan *intervalAdjust, resubmitAdjustChanSize),
 	}
-	if _, ok := engine.(consensus.Istanbul); ok || !config.IsQuorum || config.Clique != nil {
+	if _, ok := engine.(consensus.Istanbul); ok || config.Clique != nil {
 		// Subscribe NewTxsEvent for tx pool
 		worker.txsSub = eth.TxPool().SubscribeNewTxsEvent(worker.txsCh)
 		// Subscribe events for blockchain


### PR DESCRIPTION
Fixes #802 
If isQuorum is set to false in genesis when using Raft, then after around 13-20 transactions are processed, all further transactions go into pending state and are not processed.

Issue is due to this historic [commit](https://github.com/jpmorganchase/quorum/commit/30a2c8c7ef53730b15d8e25433baabfe17a5dd4e#diff-83814d75e37ea3b4eb16ffc7202295d3) where Raft is unsubscribed from chainheadevent, but it doesn't take effect when isQuorum is false.
Note that current codebase explicitly executes this code for consensus mechanisms that require it (Istanbul & Clique).
