### PR TITLE
Raft issue 795 fix

### DIFF
--- a/raft/handler.go
+++ b/raft/handler.go
@@ -765,7 +765,7 @@ func (pm *ProtocolManager) eventLoop() {
 					case raftpb.ConfChangeAddNode:
 						if pm.isRaftIdRemoved(raftId) {
 							log.Info("ignoring ConfChangeAddNode for permanently-removed peer", "raft id", raftId)
-						} else if peer := pm.peers[raftId]; peer != nil && raftId <= uint16(len(pm.bootstrapNodes))  {
+						} else if pm.isRaftIdUsed(raftId) && raftId <= uint16(len(pm.bootstrapNodes))  {
 							// See initial cluster logic in startRaft() for more information.
 							log.Info("ignoring expected ConfChangeAddNode for initial peer", "raft id", raftId)
 


### PR DESCRIPTION
Fix https://github.com/jpmorganchase/quorum/issues/795 and in the meanwhile do not break https://github.com/jpmorganchase/quorum/issues/642

After analysis, the root cause is that on a single node scenario the condition `peer := pm.peers[raftId]; peer != nil` restricts the node from setting `forceSnapshot` to true. Thus, the raft snapshot is not written into WAL. When the node restarted, raft cluster is lost. `pm.isRaftIdUsed(raftId)` provides the fix by checking if raftId is the node itself.