### PR TITLE
Use the "not in use" tx manager when env var not used

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -275,3 +275,7 @@ func quorumValidateConsensus(stack *node.Node, isRaft bool) {
 		utils.Fatalf("Consensus not specified. Exiting!!")
 	}
 }
+
+func quorumValidatePrivateTransactionManager() bool {
+	return os.Getenv("PRIVATE_CONFIG") == ""
+}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -271,6 +272,11 @@ func geth(ctx *cli.Context) error {
 	if args := ctx.Args(); len(args) > 0 {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
+
+	if !quorumValidatePrivateTransactionManager() {
+		return errors.New("the PRIVATE_CONFIG environment variable must be specified, refer to documentation")
+	}
+
 	node := makeFullNode(ctx)
 	startNode(ctx, node)
 

--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -18,12 +18,12 @@ type Constellation struct {
 }
 
 var (
-	ErrConstellationIsntInit = errors.New("Constellation not in use")
+	ErrPrivateTransactionManagerNotUsed = errors.New("private transaction manager not in use")
 )
 
 func (g *Constellation) Send(data []byte, from string, to []string) (out []byte, err error) {
 	if g.isConstellationNotInUse {
-		return nil, ErrConstellationIsntInit
+		return nil, ErrPrivateTransactionManagerNotUsed
 	}
 	out, err = g.node.SendPayload(data, from, to)
 	if err != nil {
@@ -35,7 +35,7 @@ func (g *Constellation) Send(data []byte, from string, to []string) (out []byte,
 
 func (g *Constellation) SendSignedTx(data []byte, to []string) (out []byte, err error) {
 	if g.isConstellationNotInUse {
-		return nil, ErrConstellationIsntInit
+		return nil, ErrPrivateTransactionManagerNotUsed
 	}
 	out, err = g.node.SendSignedPayload(data, to)
 	if err != nil {

--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -18,12 +18,12 @@ type Constellation struct {
 }
 
 var (
-	ErrPrivateTransactionManagerNotUsed = errors.New("private transaction manager not in use")
+	errPrivateTransactionManagerNotUsed = errors.New("private transaction manager not in use")
 )
 
 func (g *Constellation) Send(data []byte, from string, to []string) (out []byte, err error) {
 	if g.isConstellationNotInUse {
-		return nil, ErrPrivateTransactionManagerNotUsed
+		return nil, errPrivateTransactionManagerNotUsed
 	}
 	out, err = g.node.SendPayload(data, from, to)
 	if err != nil {
@@ -35,7 +35,7 @@ func (g *Constellation) Send(data []byte, from string, to []string) (out []byte,
 
 func (g *Constellation) SendSignedTx(data []byte, to []string) (out []byte, err error) {
 	if g.isConstellationNotInUse {
-		return nil, ErrPrivateTransactionManagerNotUsed
+		return nil, errPrivateTransactionManagerNotUsed
 	}
 	out, err = g.node.SendSignedPayload(data, to)
 	if err != nil {
@@ -108,11 +108,4 @@ func MustNew(path string) *Constellation {
 		panic(fmt.Sprintf("MustNew: Failed to connect to Constellation (%s): %v", path, err))
 	}
 	return g
-}
-
-func MaybeNew(path string) *Constellation {
-	if path == "" {
-		return nil
-	}
-	return MustNew(path)
 }

--- a/private/private.go
+++ b/private/private.go
@@ -13,12 +13,7 @@ type PrivateTransactionManager interface {
 }
 
 func FromEnvironment(name string) PrivateTransactionManager {
-	cfgPath := os.Getenv(name)
-	if cfgPath == "" {
-		//no privacy manager specified, start in public-only mode
-		return constellation.MustNew("ignore")
-	}
-	return constellation.MustNew(cfgPath)
+	return constellation.MustNew(os.Getenv(name))
 }
 
 var P = FromEnvironment("PRIVATE_CONFIG")

--- a/private/private.go
+++ b/private/private.go
@@ -12,12 +12,13 @@ type PrivateTransactionManager interface {
 	Receive(data []byte) ([]byte, error)
 }
 
-func FromEnvironmentOrNil(name string) PrivateTransactionManager {
+func FromEnvironment(name string) PrivateTransactionManager {
 	cfgPath := os.Getenv(name)
 	if cfgPath == "" {
-		return nil
+		//no privacy manager specified, start in public-only mode
+		return constellation.MustNew("ignore")
 	}
 	return constellation.MustNew(cfgPath)
 }
 
-var P = FromEnvironmentOrNil("PRIVATE_CONFIG")
+var P = FromEnvironment("PRIVATE_CONFIG")


### PR DESCRIPTION
If the `PRIVATE_CONFIG` environment variable isn't present, we should return an error when private transactions are sent, the same as if `PRIVATE_CONFIG=ignore` was specified.
This fixes a nil dereference crash that occurs.

Fixes https://github.com/jpmorganchase/quorum/issues/834