### PR TITLE
rpc: raise HTTP/WebSocket request size limit to 5MB

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	contentType             = "application/json"
-	maxRequestContentLength = 1024 * 512
+	maxRequestContentLength = 1024 * 1024 * 512
 )
 
 var nullAddr, _ = net.ResolveTCPAddr("tcp", "127.0.0.1:0")


### PR DESCRIPTION
Increase HTTP/WebSocket request size limit to 5MB in line with go-ethereum implementation https://github.com/ethereum/go-ethereum/blob/master/rpc/http.go#L39 