### PR TITLE
Add startup check to ensure transaction manager mode is specified

### DIFF
--- a/cmd/geth/accountcmd_test.go
+++ b/cmd/geth/accountcmd_test.go
@@ -155,7 +155,24 @@ Passphrase: {{.InputLine "foobar"}}
 	}
 }
 
+func TestGethDoesntStartWithoutPrivateTransactionManagerVariableSet(t *testing.T) {
+	defer SetResetPrivateConfig("")()
+
+	datadir := tmpDatadirWithKeystore(t)
+	geth := runGeth(t,
+		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
+		"--unlock", "f466859ead1932d743d622cb74fc058882e8648a")
+	geth.ExpectExit()
+
+	expectedText := "the PRIVATE_CONFIG environment variable must be specified for Quorum"
+	result := strings.TrimSpace(geth.StderrText())
+	if result != expectedText {
+		geth.Fatalf("bad stderr text. want '%s', got '%s'", expectedText, result)
+	}
+}
+
 func TestUnlockFlagWrongPassword(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	datadir := tmpDatadirWithKeystore(t)
 	geth := runGeth(t,
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
@@ -222,6 +239,7 @@ func TestUnlockFlagPasswordFile(t *testing.T) {
 }
 
 func TestUnlockFlagPasswordFileWrongPassword(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	datadir := tmpDatadirWithKeystore(t)
 	geth := runGeth(t,
 		"--datadir", datadir, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",
@@ -271,6 +289,7 @@ In order to avoid this warning, you need to remove the following duplicate key f
 }
 
 func TestUnlockFlagAmbiguousWrongPassword(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	store := filepath.Join("..", "..", "accounts", "keystore", "testdata", "dupes")
 	geth := runGeth(t,
 		"--keystore", store, "--nat", "none", "--nodiscover", "--maxpeers", "0", "--port", "0",

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -275,3 +275,9 @@ func quorumValidateConsensus(stack *node.Node, isRaft bool) {
 		utils.Fatalf("Consensus not specified. Exiting!!")
 	}
 }
+
+// quorumValidatePrivateTransactionManager returns whether the "PRIVATE_CONFIG"
+// environment variable is set
+func quorumValidatePrivateTransactionManager() bool {
+	return os.Getenv("PRIVATE_CONFIG") != ""
+}

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -70,6 +70,7 @@ var genesis = `{
 // Tests that a node embedded within a console can be started up properly and
 // then terminated by closing the input stream.
 func TestConsoleWelcome(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	coinbase := "0x491937757d1b26e29c507b8d4c0b233c2747e68d"
 
 	datadir := setupIstanbul(t)
@@ -107,6 +108,7 @@ at block: 0 ({{niltime}})
 
 // Tests that a console can be attached to a running node via various means.
 func TestIPCAttachWelcome(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	// Configure the instance for IPC attachement
 	coinbase := "0x491937757d1b26e29c507b8d4c0b233c2747e68d"
 	var ipc string
@@ -134,6 +136,7 @@ func TestIPCAttachWelcome(t *testing.T) {
 }
 
 func TestHTTPAttachWelcome(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	coinbase := "0x491937757d1b26e29c507b8d4c0b233c2747e68d"
 	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
 
@@ -152,6 +155,7 @@ func TestHTTPAttachWelcome(t *testing.T) {
 }
 
 func TestWSAttachWelcome(t *testing.T) {
+	defer SetResetPrivateConfig("ignore")()
 	coinbase := "0x491937757d1b26e29c507b8d4c0b233c2747e68d"
 	port := strconv.Itoa(trulyRandInt(1024, 65536)) // Yeah, sometimes this will fail, sorry :P
 
@@ -230,4 +234,12 @@ func setupIstanbul(t *testing.T) string {
 	runGeth(t, "--datadir", datadir, "init", json).WaitExit()
 
 	return datadir
+}
+
+func SetResetPrivateConfig(value string) func() {
+	existingValue := os.Getenv("PRIVATE_CONFIG")
+	os.Setenv("PRIVATE_CONFIG", value)
+	return func() {
+		os.Setenv("PRIVATE_CONFIG", existingValue)
+	}
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -271,6 +272,11 @@ func geth(ctx *cli.Context) error {
 	if args := ctx.Args(); len(args) > 0 {
 		return fmt.Errorf("invalid command: %q", args[0])
 	}
+
+	if !quorumValidatePrivateTransactionManager() {
+		return errors.New("the PRIVATE_CONFIG environment variable must be specified for Quorum")
+	}
+
 	node := makeFullNode(ctx)
 	startNode(ctx, node)
 

--- a/private/constellation/constellation.go
+++ b/private/constellation/constellation.go
@@ -18,12 +18,12 @@ type Constellation struct {
 }
 
 var (
-	ErrConstellationIsntInit = errors.New("Constellation not in use")
+	errPrivateTransactionManagerNotUsed = errors.New("private transaction manager not in use")
 )
 
 func (g *Constellation) Send(data []byte, from string, to []string) (out []byte, err error) {
 	if g.isConstellationNotInUse {
-		return nil, ErrConstellationIsntInit
+		return nil, errPrivateTransactionManagerNotUsed
 	}
 	out, err = g.node.SendPayload(data, from, to)
 	if err != nil {
@@ -35,7 +35,7 @@ func (g *Constellation) Send(data []byte, from string, to []string) (out []byte,
 
 func (g *Constellation) SendSignedTx(data []byte, to []string) (out []byte, err error) {
 	if g.isConstellationNotInUse {
-		return nil, ErrConstellationIsntInit
+		return nil, errPrivateTransactionManagerNotUsed
 	}
 	out, err = g.node.SendSignedPayload(data, to)
 	if err != nil {
@@ -108,11 +108,4 @@ func MustNew(path string) *Constellation {
 		panic(fmt.Sprintf("MustNew: Failed to connect to Constellation (%s): %v", path, err))
 	}
 	return g
-}
-
-func MaybeNew(path string) *Constellation {
-	if path == "" {
-		return nil
-	}
-	return MustNew(path)
 }


### PR DESCRIPTION
If the `PRIVATE_CONFIG` environment variable isn't present, or set to the empty string, the node no longer starts up and prints an error telling the user that the environment variable should be specified. This way, we explicitly know what mode the user wishes to run their node in, and will not try to query a `nil` Private Transaction Manager.

Also updates the error message on private transactions when the PTM is not in use to be generic for all PTMs.

Supersedes https://github.com/jpmorganchase/quorum/pull/836
Fixes #834