### PR TITLE
Optimize travis and fix flaky tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,15 +86,11 @@ matrix:
           fi
     - if: tag IS blank
       os: osx
-      osx_image: xcode9.2 # so we don't have to deal with Kernel Extension Consent UI which is never possible in CI
       script:
         - |
-          brew update
-          brew install caskroom/cask/brew-cask
-          brew cask install osxfuse
           go run build/ci.go install
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            QUORUM_IGNORE_TEST_PACKAGES=github.com/ethereum/go-ethereum/swarm go run build/ci.go test -coverage $TEST_PACKAGES
+            QUORUM_IGNORE_TEST_PACKAGES=github.com/ethereum/go-ethereum/swarm,github.com/ethereum/go-ethereum/cmd/swarm go run build/ci.go test -coverage $TEST_PACKAGES
           else
             go run build/ci.go test -coverage $TEST_PACKAGES
           fi
@@ -111,7 +107,6 @@ matrix:
 
     - if: tag IS present
       os: osx
-      osx_image: xcode9.2
       env: OUTPUT_FILE=geth_${TRAVIS_TAG}_darwin_amd64.tar.gz
       script:
         - build/env.sh go run build/ci.go install ./cmd/geth

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
           sudo chown root:$USER /etc/fuse.conf
           go run build/ci.go install
           if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-            QUORUM_IGNORE_TEST_PACKAGES=github.com/ethereum/go-ethereum/swarm go run build/ci.go test -coverage $TEST_PACKAGES
+            QUORUM_IGNORE_TEST_PACKAGES=github.com/ethereum/go-ethereum/swarm,github.com/ethereum/go-ethereum/cmd/swarm go run build/ci.go test -coverage $TEST_PACKAGES
           else
             go run build/ci.go test -coverage $TEST_PACKAGES
           fi

--- a/eth/fetcher/fetcher_test.go
+++ b/eth/fetcher/fetcher_test.go
@@ -244,7 +244,7 @@ func verifyImportEvent(t *testing.T, imported chan *types.Block, arrive bool) {
 		select {
 		case <-imported:
 			t.Fatalf("import invoked")
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(20 * time.Millisecond):
 		}
 	}
 }

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -225,7 +225,7 @@ func testEmptyWork(t *testing.T, chainConfig *params.ChainConfig, engine consens
 	for i := 0; i < 2; i += 1 {
 		select {
 		case <-taskCh:
-		case <-time.NewTimer(time.Second).C:
+		case <-time.NewTimer(2 * time.Second).C:
 			t.Error("new task timeout")
 		}
 	}

--- a/p2p/protocols/protocol_test.go
+++ b/p2p/protocols/protocol_test.go
@@ -269,8 +269,11 @@ func TestProtocolHook(t *testing.T) {
 	if !testHook.send {
 		t.Fatal("Expected a send message, but it is not")
 	}
-	if testHook.peer == nil || testHook.peer.ID() != tester.Nodes[0].ID() {
-		t.Fatal("Expected peer ID to be set correctly, but it is not")
+	if testHook.peer == nil {
+		t.Fatal("Expected peer to be set, is nil")
+	}
+	if peerId := testHook.peer.ID(); peerId != tester.Nodes[0].ID() && peerId != tester.Nodes[1].ID() {
+		t.Fatalf("Expected peer ID to be set correctly, but it is not (got %v, exp %v or %v", peerId, tester.Nodes[0].ID(), tester.Nodes[1].ID())
 	}
 	if testHook.size != 11 { //11 is the length of the encoded message
 		t.Fatalf("Expected size to be %d, but it is %d ", 1, testHook.size)


### PR DESCRIPTION
- Added `cmd/swarm` package to ignore when tests are run.
- Removing install of `osxfuse`
- Fixing flaky tests by cherry picking from go-ethereum [PR#18508](https://github.com/ethereum/go-ethereum/pull/18508) 