### PR TITLE
trie/database: fix overflow in parent tracking (cherrypicking go-ethereum#18165 pull)

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -134,7 +134,7 @@ type cachedNode struct {
 	node node   // Cached collapsed trie node, or raw rlp data
 	size uint16 // Byte size of the useful cached data
 
-	parents  uint16                 // Number of live nodes referencing this one
+	parents  uint32                 // Number of live nodes referencing this one
 	children map[common.Hash]uint16 // External children referenced by this node
 
 	flushPrev common.Hash // Previous node in the flush-list


### PR DESCRIPTION
We had an issue on an IBFT network whereby we were seeing some nodes fail with 'BAD BLOCK' due to the error 'invalid gas used'. These nodes would then be unable to recover unless their chain was deleted and fast resync performed.

Analysis showed the following was occurring:

- User was creating a contract which was being repetitively called during perf testing.
- Multiple successive contracts were created.
- After some time, due to node.parent being int16, it was overflowing to value zero. This causes the contract to be flushed from the in-memory trie.
- Any further calls to the contract would fail, resulting in gas consumption of 21272 (intrinsic gas).

However, on another node (which had been restarted at some point):

- The contract was still available in the in-memory trie, so the contract call succeeded and consumed  much higher gas value.
- This meant that the block gas usage was higher on this node than the value stamped in the header, and the block was rejected.

Note that this issue does not occur if the nodes are set up as ‘archive’ nodes, as this disables pruning.

Cherrypicking [go-ethereum#18165](https://github.com/ethereum/go-ethereum/pull/18165) pull.
