### PR TITLE
Fix premature abort during blocks processing for raft

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1149,6 +1149,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		// If the chain is terminating, stop processing blocks
 		if atomic.LoadInt32(&bc.procInterrupt) == 1 {
 			log.Debug("Premature abort during blocks processing")
+			// QUORUM
+			if bc.chainConfig.Istanbul == nil && bc.chainConfig.Clique == nil {
+				return i, events, coalescedLogs, ErrInsertChainInterrupted
+			}
+			// END QUORUM
 			break
 		}
 		// If the header is a banned one, straight out abort

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1150,7 +1150,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 		if atomic.LoadInt32(&bc.procInterrupt) == 1 {
 			log.Debug("Premature abort during blocks processing")
 			// QUORUM
-			if bc.chainConfig.Istanbul == nil && bc.chainConfig.Clique == nil {
+			if bc.chainConfig.IsQuorum && bc.chainConfig.Istanbul == nil && bc.chainConfig.Clique == nil {
 				// Only returns an error for raft mode
 				return i, events, coalescedLogs, ErrAbortBlocksProcessing
 			}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1151,7 +1151,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks) (int, []interface{}, []*ty
 			log.Debug("Premature abort during blocks processing")
 			// QUORUM
 			if bc.chainConfig.Istanbul == nil && bc.chainConfig.Clique == nil {
-				return i, events, coalescedLogs, ErrInsertChainInterrupted
+				// Only returns an error for raft mode
+				return i, events, coalescedLogs, ErrAbortBlocksProcessing
 			}
 			// END QUORUM
 			break

--- a/core/error.go
+++ b/core/error.go
@@ -33,6 +33,6 @@ var (
 	// next one expected based on the local chain.
 	ErrNonceTooHigh = errors.New("nonce too high")
 
-	// ErrInsertChainInterrupted is returned if bc.insertChain is interrupted under raft mode
-	ErrInsertChainInterrupted = errors.New("chain insertion interrupted")
+	// ErrAbortBlocksProcessing is returned if bc.insertChain is interrupted under raft mode
+	ErrAbortBlocksProcessing = errors.New("abort during blocks processing")
 )

--- a/core/error.go
+++ b/core/error.go
@@ -32,4 +32,7 @@ var (
 	// ErrNonceTooHigh is returned if the nonce of a transaction is higher than the
 	// next one expected based on the local chain.
 	ErrNonceTooHigh = errors.New("nonce too high")
+
+	// ErrInsertChainInterrupted is returned if bc.insertChain is interrupted under raft mode
+	ErrInsertChainInterrupted = errors.New("chain insertion interrupted")
 )

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -894,12 +894,11 @@ func (pm *ProtocolManager) applyNewChainHead(block *types.Block) bool {
 		_, err := pm.blockchain.InsertChain([]*types.Block{block})
 
 		if err != nil {
-			if err == core.ErrInsertChainInterrupted {
-				log.Debug("Insert chain interrupted... Please restart node.")
+			if err == core.ErrAbortBlocksProcessing {
+				log.Error(fmt.Sprintf("failed to extend chain: %s", err.Error()))
 				return false
-			} else {
-				panic(fmt.Sprintf("failed to extend chain: %s", err.Error()))
 			}
+			panic(fmt.Sprintf("failed to extend chain: %s", err.Error()))
 		}
 
 		log.EmitCheckpoint(log.BlockCreated, "block", fmt.Sprintf("%x", block.Hash()))


### PR DESCRIPTION
Fix https://github.com/jpmorganchase/quorum/issues/852

Prevent raft from updating persisted storage when `bc.insertChain` is interrupted. This fixes the issue of chain fork and constant `InvalidRaftOrdering`.