### PR TITLE
Fix for Raft stability 

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1323,3 +1323,8 @@ func checkAccount(fromAcct common.Address, toAcct *common.Address) error {
 	}
 	return nil
 }
+
+// helper function to return chainHeadChannel size
+func GetChainHeadChannleSize() int {
+	return chainHeadChanSize
+}

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -110,7 +110,7 @@ func NewProtocolManager(raftId uint16, raftPort uint16, blockchain *core.BlockCh
 		joinExisting:        joinExisting,
 		blockchain:          blockchain,
 		eventMux:            mux,
-		blockProposalC:      make(chan *types.Block),
+		blockProposalC:      make(chan *types.Block, 10),
 		confChangeProposalC: make(chan raftpb.ConfChange),
 		httpstopc:           make(chan struct{}),
 		httpdonec:           make(chan struct{}),

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -89,7 +89,7 @@ func newMinter(config *params.ChainConfig, eth *RaftService, blockTime time.Dura
 		speculativeChain: newSpeculativeChain(),
 
 		invalidRaftOrderingChan: make(chan InvalidRaftOrdering, 1),
-		chainHeadChan:           make(chan core.ChainHeadEvent, 10),
+		chainHeadChan:           make(chan core.ChainHeadEvent, core.GetChainHeadChannleSize()),
 		txPreChan:               make(chan core.NewTxsEvent, 4096),
 	}
 

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -89,7 +89,7 @@ func newMinter(config *params.ChainConfig, eth *RaftService, blockTime time.Dura
 		speculativeChain: newSpeculativeChain(),
 
 		invalidRaftOrderingChan: make(chan InvalidRaftOrdering, 1),
-		chainHeadChan:           make(chan core.ChainHeadEvent, 1),
+		chainHeadChan:           make(chan core.ChainHeadEvent, 10),
 		txPreChan:               make(chan core.NewTxsEvent, 4096),
 	}
 
@@ -213,7 +213,7 @@ func throttle(rate time.Duration, f func()) func() {
 
 		for range ticker.C {
 			<-request.Out()
-			go f()
+			f()
 		}
 	}()
 


### PR DESCRIPTION
increased the size of blockProposal and chainHeadEvent channels. Changed the call to mintNewBlock from a go routine to a function call. Changes done to improve performance of Raft in high load envs