### PR TITLE
Setting maxRequestContentLength to 5mb

### DIFF
--- a/rpc/http.go
+++ b/rpc/http.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	contentType             = "application/json"
-	maxRequestContentLength = 1024 * 1024 * 512
+	maxRequestContentLength = 1024 * 1024 * 5
 )
 
 var nullAddr, _ = net.ResolveTCPAddr("tcp", "127.0.0.1:0")


### PR DESCRIPTION
Set `maxRequestContentLength` to 5mb to align with upstream