### PR TITLE
fix raft minter

### DIFF
--- a/raft/minter.go
+++ b/raft/minter.go
@@ -265,7 +265,7 @@ func (minter *minter) createWork() *work {
 		GasLimit:   minter.eth.calcGasLimitFunc(parent),
 		GasUsed:    0,
 		Coinbase:   minter.coinbase,
-		Time:       big.NewInt(tstamp),
+		Time:       big.NewInt(time.Now().Unix()),
 	}
 
 	publicState, privateState, err := minter.chain.StateAt(parent.Root())

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -43,7 +43,7 @@ func TestSignHeader(t *testing.T) {
 		GasLimit:   uint64(0),
 		GasUsed:    uint64(0),
 		Coinbase:   minter.coinbase,
-		Time:       big.NewInt(time.Now().UnixNano()),
+		Time:       big.NewInt(time.Now().Unix()),
 	}
 
 	headerHash := header.Hash()


### PR DESCRIPTION
using nanoseconds instead of normal seconds in Time field of block head stucks ethereumjs, change back to seconds since epoch