### PR TITLE
Update DNS document for raft

### DIFF
--- a/docs/Features/dns.md
+++ b/docs/Features/dns.md
@@ -19,11 +19,11 @@ resolved.
 ## Compatibility
 For Raft, the whole network must be on version 2.4.0 of Quorum for DNS to function properly.  DNS must 
 be explicitly enabled using the `--raftdnsenable` flag for each node once the node has migrated to version 2.4.0 of Quorum
-The network can still run in fine when some nodes are in 2.4.0 version and some in older version as long as this feature is not enabled. For safe migration the recommended approach is as below:
+The network runs fine when some nodes are in 2.4.0 version and some in older version as long as this feature is not enabled. For safe migration the recommended approach is as below:
 * migrate the nodes to `geth` 2.4.0 version without using `--raftdnsenable` flag
 * once the network is fully migrated, restart the nodes with `--raftdnsenable` to enable the feature
 
 Please note that in a partially migrated network  (where some nodes are on version 2.4.0 and others on lower version) **with DNS feature enabled** for migrated nodes, `raft.addPeer` should not be invoked with Hostname till entire network migrates to 2.4.0 version. If invoked, this call will crash all nodes running in older version and these nodes will have to restarted with `geth` of version 2.4.0 of Quorum. `raft.addPeer` can still be invoked with IP address and network will work fine. 
 
-### Known Issue
-In a network where all nodes are running on Quorum version 2.4.0, with few nodes enabled for DNS, we recommend the `--verbosity` to be 3 or below. We have observed that nodes which are not enabled for DNS fail to restart if `raft.addPeer` is invoked with host name if `--verbosity` is set above 3. We are working on this issue.
+### Note
+In a network where all nodes are running on Quorum version 2.4.0, with few nodes enabled for DNS, we recommend the `--verbosity` to be 3 or below. We have observed that nodes which are not enabled for DNS fail to restart if `raft.addPeer` is invoked with host name if `--verbosity` is set above 3. We are currently fixing the same.

--- a/docs/Features/dns.md
+++ b/docs/Features/dns.md
@@ -26,4 +26,6 @@ The network runs fine when some nodes are in 2.4.0 version and some in older ver
 Please note that in a partially migrated network  (where some nodes are on version 2.4.0 and others on lower version) **with DNS feature enabled** for migrated nodes, `raft.addPeer` should not be invoked with Hostname till entire network migrates to 2.4.0 version. If invoked, this call will crash all nodes running in older version and these nodes will have to restarted with `geth` of version 2.4.0 of Quorum. `raft.addPeer` can still be invoked with IP address and network will work fine. 
 
 ### Note
-In a network where all nodes are running on Quorum version 2.4.0, with few nodes enabled for DNS, we recommend the `--verbosity` to be 3 or below. We have observed that nodes which are not enabled for DNS fail to restart if `raft.addPeer` is invoked with host name if `--verbosity` is set above 3. We are currently fixing the same.
+In a network where all nodes are running on Quorum version 2.4.0, with few nodes enabled for DNS, we recommend the
+ `--verbosity` to be 3 or below. We have observed that nodes which are not enabled for DNS fail to restart if 
+ `raft.addPeer` is invoked with host name if `--verbosity` is set above 3.

--- a/docs/Features/dns.md
+++ b/docs/Features/dns.md
@@ -17,7 +17,10 @@ DNS is not supported for the discovery protocol. Use a bootnode instead, which c
 resolved.
 
 ## Compatibility
-For Raft, the whole network must be on version 2.3.1 of Quorum for DNS to function properly; because of this, DNS must 
-be explicitly enabled using the `--raftdnsenable` flag. 
-The network will support older nodes mixed with newer nodes if DNS is not enabled via this flag, and it is safe to 
-enable DNS only on some nodes if all nodes are on at least version 2.3.1. This allows for a clear upgrade path.
+For Raft, the whole network must be on version 2.4.0 of Quorum for DNS to function properly.  DNS must 
+be explicitly enabled using the `--raftdnsenable` flag for each node once the node has migrated to version 2.4.0 of Quorum
+The network can still run in fine when some nodes are in 2.4.0 version and some in older version as long as this feature is not enabled. For safe migration the recommended approach is as below:
+* migrate the nodes to `geth` 2.4.0 version without using `--raftdnsenable` flag
+* once the network is fully migrated, restart the nodes with `--raftdnsenable` to enable the feature
+
+Please note that in a partially migrated network  (where some nodes are on version 2.4.0 and others on lower version) **with DNS feature enabled** for migrated nodes, `raft.addPeer` should not be invoked with Hostname till entire network migrates to 2.4.0 version. `raft.addPeer` can still be invoked with IP address and network will work fine. 

--- a/docs/Features/dns.md
+++ b/docs/Features/dns.md
@@ -23,4 +23,7 @@ The network can still run in fine when some nodes are in 2.4.0 version and some 
 * migrate the nodes to `geth` 2.4.0 version without using `--raftdnsenable` flag
 * once the network is fully migrated, restart the nodes with `--raftdnsenable` to enable the feature
 
-Please note that in a partially migrated network  (where some nodes are on version 2.4.0 and others on lower version) **with DNS feature enabled** for migrated nodes, `raft.addPeer` should not be invoked with Hostname till entire network migrates to 2.4.0 version. `raft.addPeer` can still be invoked with IP address and network will work fine. 
+Please note that in a partially migrated network  (where some nodes are on version 2.4.0 and others on lower version) **with DNS feature enabled** for migrated nodes, `raft.addPeer` should not be invoked with Hostname till entire network migrates to 2.4.0 version. If invoked, this call will crash all nodes running in older version and these nodes will have to restarted with `geth` of version 2.4.0 of Quorum. `raft.addPeer` can still be invoked with IP address and network will work fine. 
+
+### Known Issue
+In a network where all nodes are running on Quorum version 2.4.0, with few nodes enabled for DNS, we recommend the `--verbosity` to be 3 or below. We have observed that nodes which are not enabled for DNS fail to restart if `raft.addPeer` is invoked with host name if `--verbosity` is set above 3. We are working on this issue.


### PR DESCRIPTION
Updates the document for using DNS under raft consensus with a more clear upgrade path and known issue list.