### PR TITLE
Add Quorum eth namespace RPC methods to console

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1784,12 +1784,12 @@ func (s *PublicTransactionPoolAPI) send(ctx context.Context, asyncArgs AsyncSend
 		buf := new(bytes.Buffer)
 		err := json.NewEncoder(buf).Encode(resultResponse)
 		if err != nil {
-			log.Info("Error encoding callback JSON: %v", err)
+			log.Info("Error encoding callback JSON", "err", err.Error())
 			return
 		}
 		_, err = http.Post(asyncArgs.CallbackUrl, "application/json", buf)
 		if err != nil {
-			log.Info("Error sending callback: %v", err)
+			log.Info("Error sending callback", "err", err.Error())
 			return
 		}
 	}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -501,7 +501,21 @@ web3._extend({
 			call: 'eth_storageRoot',
 			params: 2,
 			inputFormatter: [web3._extend.formatters.inputAddressFormatter, null]
-		})
+		}),
+		// QUORUM
+		new web3._extend.Method({
+			name: 'sendTransactionAsync',
+			call: 'eth_sendTransactionAsync',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getQuorumPayload',
+			call: 'eth_getQuorumPayload',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		// END-QUORUM
 	],
 	properties: [
 		new web3._extend.Property({


### PR DESCRIPTION
Methods are not automatically added to the built-in JS console, even though they may be available over the RPC API. Two Quorum specific methods (`eth_getQuorumPayload` and `eth_sendTransactionAsync`) were not updated to be accessible via the JS console. This commit adds them.
**note**: adding them under the `eth` namespace in a separate subsection didn't seem to work, so I've added Quorum comment boundary markers.

During testing of `eth_sendTransactionAsync` to see if the extra parameters outside of upstream `SendTxArgs` object are kept using the web3.js `inputTransactionFormatter` are retained (they are, so using the formatter is okay), I found two log messages not using the correct logging format, so they have been updated to use the proper number of arguments.