### PR TITLE
maxCodeSizeChangeBlock to genesis for tracking maxCodeSize value change

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -488,7 +488,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	ret, err := run(evm, contract, nil, false)
 
 	var maxCodeSize int
-	if evm.ChainConfig().MaxCodeSize > 0 {
+	if evm.chainConfig.IsMaxCodeSizeChangeBlock(evm.BlockNumber) && evm.ChainConfig().MaxCodeSize > 0 {
 		maxCodeSize = int(evm.ChainConfig().MaxCodeSize * 1024)
 	} else {
 		maxCodeSize = params.MaxCodeSize

--- a/params/config.go
+++ b/params/config.go
@@ -133,19 +133,19 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32, 50, big.NewInt(0)}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32, 50, big.NewInt(0), big.NewInt(0)}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, false, 32, 32, big.NewInt(0)}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, false, 32, 32, big.NewInt(0), big.NewInt(0)}
 
-	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32, 32, big.NewInt(0)}
+	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil, false, 32, 32, big.NewInt(0), big.NewInt(0)}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 
-	QuorumTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, nil, common.Hash{}, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64, 32, big.NewInt(0)}
+	QuorumTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, nil, common.Hash{}, nil, nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64, 32, big.NewInt(0), big.NewInt(0)}
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
@@ -196,6 +196,7 @@ type ChainConfig struct {
 	//
 	// QIP714Block implements the permissions related changes
 	QIP714Block *big.Int `json:"qip714Block,omitempty"`
+	MaxCodeSizeChangeBlock *big.Int `json:"maxCodeSizeChangeBlock,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -318,6 +319,13 @@ func (c *ChainConfig) IsEWASM(num *big.Int) bool {
 func (c *ChainConfig) IsQIP714(num *big.Int) bool {
 	return isForked(c.QIP714Block, num)
 }
+// Quorum
+//
+// IsMaxCodeSizeChangeBlock returns whether num represents a block number max code size
+// was changed from default 24K to new value
+func (c *ChainConfig) IsMaxCodeSizeChangeBlock(num *big.Int) bool {
+	return isForked(c.MaxCodeSizeChangeBlock, num)
+}
 
 // GasTable returns the gas table corresponding to the current phase (homestead or homestead reprice).
 //
@@ -395,6 +403,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int, isQuor
 	}
 	if isForkIncompatible(c.QIP714Block, newcfg.QIP714Block, head) {
 		return newCompatError("permissions fork block", c.QIP714Block, newcfg.QIP714Block)
+	}
+	if isForkIncompatible(c.MaxCodeSizeChangeBlock, newcfg.MaxCodeSizeChangeBlock, head) {
+		return newCompatError("max code size change fork block", c.MaxCodeSizeChangeBlock, newcfg.MaxCodeSizeChangeBlock)
 	}
 	return nil
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -87,6 +87,41 @@ func TestCheckCompatible(t *testing.T) {
 				RewindTo:     9,
 			},
 		},
+		{
+			stored: &ChainConfig{MaxCodeSizeChangeBlock:big.NewInt(10)},
+			new:    &ChainConfig{MaxCodeSizeChangeBlock:big.NewInt(20)},
+			head:   30,
+			wantErr: &ConfigCompatError{
+				What:         "max code size change fork block",
+				StoredConfig: big.NewInt(10),
+				NewConfig:    big.NewInt(20),
+				RewindTo:     9,
+			},
+		},
+		{
+			stored:  &ChainConfig{MaxCodeSizeChangeBlock:big.NewInt(10)},
+			new:     &ChainConfig{MaxCodeSizeChangeBlock:big.NewInt(20)},
+			head:    4,
+			wantErr: nil,
+		},
+		{
+			stored: &ChainConfig{QIP714Block:big.NewInt(10)},
+			new:    &ChainConfig{QIP714Block:big.NewInt(20)},
+			head:   30,
+			wantErr: &ConfigCompatError{
+				What:         "permissions fork block",
+				StoredConfig: big.NewInt(10),
+				NewConfig:    big.NewInt(20),
+				RewindTo:     9,
+			},
+		},
+		{
+			stored:  &ChainConfig{QIP714Block:big.NewInt(10)},
+			new:     &ChainConfig{QIP714Block:big.NewInt(20)},
+			head:    4,
+			wantErr: nil,
+		},
+
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Added `maxCodeSizeChangeBlock` to track the block number when the `maxCodeSize` changes from default 24K to the value given.
For long standing networks, it is possible that contracts which crossed default 24k size were deployed at some time and the network rejected the same with `max code size exceeded` error. If the network at later point changed the maxCodeSize to a higher value and post this if a new node joins the network, the new node will sync the old blocks with the higher max code size value and thus the gas computed on the historical block will be different from the network resulting in bad block error. 
`maxCodeSizeChangeBlock` has been added track the block number where the new `maxCodeSize` value was set for the network overwriting the default value of 24K.  This will ensure that any new nodes joining the network will be able to sync the historical blocks without the bad block error. 

However, it should be noted that, if `maxCodeSize` has been changed several times at network level, `maxCodeSizeChangeBlock` will only track the last change and for all other prior blocks it will take 24K as the default `maxCodeSize`. In this scenario, its possible to get the bad blocks error at the time of network sync

#942 