### PR TITLE
travis: update gauge version

### DIFF
--- a/build/travis-install-linux.sh
+++ b/build/travis-install-linux.sh
@@ -40,7 +40,7 @@ wget https://github.com/jpmorganchase/tessera/releases/download/tessera-0.8/tess
 echo "---> tessera done"
 
 echo "---> getting gauge jar ..."
-wget https://github.com/getgauge/gauge/releases/download/v1.0.4/gauge-1.0.4-linux.x86_64.zip -O gauge.zip -q
+wget https://github.com/getgauge/gauge/releases/download/v1.0.7/gauge-1.0.7-linux.x86_64.zip -O gauge.zip -q
 sudo unzip -o gauge.zip -d /usr/local/bin
 gauge telemetry off
 cd ${TRAVIS_HOME}/quorum-acceptance-tests


### PR DESCRIPTION
Update to 1.0.7 to fix issue with gauge java version mismatched with ones in `quorum-acceptance-tests`