### PR TITLE
plugin: delegate JSON RPC calls to plugin

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -27,14 +27,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/plugin"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/plugin"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/prometheus/prometheus/util/flock"
 )

--- a/plugin/base.go
+++ b/plugin/base.go
@@ -13,12 +13,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/hashicorp/go-hclog"
-
 	iplugin "github.com/ethereum/go-ethereum/internal/plugin"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/plugin/initializer"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 )
 

--- a/plugin/service_test.go
+++ b/plugin/service_test.go
@@ -27,7 +27,9 @@ func TestPluginManager_ProvidersPopulation(t *testing.T) {
 	defer func() {
 		delete(pluginProviders, arbitraryPluginInterfaceName)
 	}()
-	pluginProviders[arbitraryPluginInterfaceName] = plugin.PluginSet{}
+	pluginProviders[arbitraryPluginInterfaceName] = pluginProvider{
+		pluginSet: plugin.PluginSet{},
+	}
 
 	testObject, err := NewPluginManager("arbitraryName", &Settings{
 		Providers: map[PluginInterfaceName]PluginDefinition{
@@ -72,6 +74,16 @@ func TestPluginManager_GetPlugin_whenReadFromCache(t *testing.T) {
 
 	assert.True(ok)
 	assert.Equal(p, actual)
+}
+
+func TestPluginManager_GetPlugin_whenReadFromInitializedPluginsCache(t *testing.T) {
+	assert := testifyassert.New(t)
+	testObject := typicalPluginManager(t)
+
+	actual, ok := testObject.getPlugin(HelloWorldPluginInterfaceName)
+
+	assert.True(ok)
+	assert.IsType(new(basePlugin), actual)
 }
 
 func TestPluginManager_GetPluginTemplate_whenReadFromCache(t *testing.T) {

--- a/plugin/settings.go
+++ b/plugin/settings.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/plugin/helloworld"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/hashicorp/go-plugin"
-
 	"github.com/naoina/toml"
 )
 
@@ -22,10 +22,28 @@ const (
 )
 
 var (
-	// define additional plugins here
-	pluginProviders = map[PluginInterfaceName]plugin.PluginSet{
+	// define additional plugins being supported here
+	pluginProviders = map[PluginInterfaceName]pluginProvider{
 		HelloWorldPluginInterfaceName: {
-			helloworld.ConnectorName: &helloworld.PluginConnector{},
+			apiProviderFunc: func(ns string, pm *PluginManager) ([]rpc.API, error) {
+				template := new(HelloWorldPluginTemplate)
+				if err := pm.GetPluginTemplate(HelloWorldPluginInterfaceName, template); err != nil {
+					return nil, err
+				}
+				service, err := template.Get()
+				if err != nil {
+					return nil, err
+				}
+				return []rpc.API{{
+					Namespace: ns,
+					Version:   "1.0.0",
+					Service:   service,
+					Public:    true,
+				}}, nil
+			},
+			pluginSet: plugin.PluginSet{
+				helloworld.ConnectorName: &helloworld.PluginConnector{},
+			},
 		},
 	}
 
@@ -38,6 +56,15 @@ var (
 	}
 )
 
+type pluginProvider struct {
+	// this allows exposing plugin interfaces to geth RPC API automatically.
+	// nil value implies that plugin won't expose its methods to geth RPC API
+	apiProviderFunc rpcAPIProviderFunc
+	// contains connectors being registered to the plugin library
+	pluginSet plugin.PluginSet
+}
+
+type rpcAPIProviderFunc func(ns string, pm *PluginManager) ([]rpc.API, error)
 type Version string
 
 // This is to describe a plugin

--- a/plugin/settings_test.go
+++ b/plugin/settings_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/naoina/toml"
-
 	testifyassert "github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
By providing `apiProviderFunc` implementation, plugin can expose their APIs
via internal plugin interfaces to geth JSON RPC by convention:

`plugin@<plugin interface name>_<api>`

E.g.: `plugin@helloworld_greeting`
`plugin@helloworld` namespace must be provided via `--rpcapi` or `--wsapi` arguments