### PR TITLE
travis: reduce the time running Travis for PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,13 +80,6 @@ matrix:
           sudo chown root:$USER /etc/fuse.conf
           go run build/ci.go install
           QUORUM_IGNORE_TEST_PACKAGES=github.com/ethereum/go-ethereum/swarm,github.com/ethereum/go-ethereum/cmd/swarm go run build/ci.go test -coverage $TEST_PACKAGES
-    - if: tag IS blank
-      os: osx
-      script:
-        - |
-          go run build/ci.go install
-          QUORUM_IGNORE_TEST_PACKAGES=github.com/ethereum/go-ethereum/swarm,github.com/ethereum/go-ethereum/cmd/swarm go run build/ci.go test -coverage $TEST_PACKAGES
-
     - if: tag IS present
       os: linux
       dist: xenial


### PR DESCRIPTION
Running unit tests in OSX env is not required due to intermittent
unit test failures.
It's sufficient to run acc tests and unit tests in Linux env for PR.
In master branch, we still run tests in both envs.