### PR TITLE
changes to set the immutability threshold for Quourm

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1640,9 +1640,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	}
 
 	// set immutability threshold in config
-	if ctx.GlobalIsSet(QuorumImmutabilityThreshold.Name) {
-		cfg.QuorumImmutabilityThreshold = ctx.GlobalInt(QuorumImmutabilityThreshold.Name)
-	}
+	params.SetQuorumImmutabilityThreshold(ctx.GlobalInt(QuorumImmutabilityThreshold.Name))
 
 	// Override any default configs for hard coded networks.
 	switch {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -150,9 +150,6 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		if (chainConfig.ChainID != nil && chainConfig.ChainID.Int64() == 1) || config.NetworkId == 1 {
 			return nil, errors.New("Cannot have chain id or network id as 1.")
 		}
-
-		// set the immutability threshold value in line with value passed
-		params.SetQuorumImmutabilityThreshold(config.QuorumImmutabilityThreshold)
 	}
 
 	if !rawdb.GetIsQuorumEIP155Activated(chainDb) && chainConfig.ChainID != nil {

--- a/eth/config.go
+++ b/eth/config.go
@@ -166,7 +166,4 @@ type Config struct {
 
 	// Istanbul block override (TODO: remove after the fork)
 	OverrideIstanbul *big.Int
-
-	// Freezer db immutability threshold
-	QuorumImmutabilityThreshold int
 }

--- a/params/network_params.go
+++ b/params/network_params.go
@@ -62,21 +62,20 @@ const (
 
 // //Quorum
 var quorumImmutabilityThreshold int
-var isQuorum = false
 
 // returns the immutability threshold set for the network
 func GetImmutabilityThreshold() int {
-	if isQuorum {
 
+	if quorumImmutabilityThreshold > 0 {
 		return quorumImmutabilityThreshold
 	}
+
 	return ImmutabilityThreshold
 }
 
 // sets the immutability threshold and isQuorum to passed values
 func SetQuorumImmutabilityThreshold(immutabilityThreshold int) {
 	quorumImmutabilityThreshold = immutabilityThreshold
-	isQuorum = true
 }
 
 // /Quorum


### PR DESCRIPTION
The freezer db was getting opened before the input immutability threshold was set in parameters. Corrected the same. 