### PR TITLE
Switch branch in travis build to master

### DIFF
--- a/build/travis-install-linux.sh
+++ b/build/travis-install-linux.sh
@@ -23,15 +23,7 @@ echo "---> building geth done"
 
 echo "---> cloning quorum-cloud and quorum-acceptance-tests ..."
 git clone https://github.com/jpmorganchase/quorum-acceptance-tests.git ${TRAVIS_HOME}/quorum-acceptance-tests
-# use quorum-geth-upgrade-1.9.7 branch
-cd ${TRAVIS_HOME}/quorum-acceptance-tests
-git checkout quorum-geth-upgrade-1.9.7
-cd -
 git clone https://github.com/jpmorganchase/quorum-cloud.git ${TRAVIS_HOME}/quorum-cloud
-# use quorum-geth-upgrade-1.9.7 branch
-cd ${TRAVIS_HOME}/quorum-cloud
-git checkout quorum-geth-upgrade-1.9.7
-cd -
 echo "---> cloning done"
 
 echo "---> getting tessera jar ..."


### PR DESCRIPTION
Travis scripts are still using `quorum-geth-upgrade-1.9.7` branch of quorum-acceptance-test and quorum-cloud to initiate build. Should switch to `master` after https://github.com/jpmorganchase/quorum-cloud/pull/15 gets merged.