### PR TITLE
eth_estimateGas failing when value is not passed as a part of argumenst

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -972,7 +972,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 	//This makes the return value a potential over-estimate of gas, rather than the exact cost to run right now
 
 	//if the transaction has a value then it cannot be private, so we can skip this check
-	if args.Value.ToInt().Cmp(big.NewInt(0)) == 0 {
+	if args.Value != nil && args.Value.ToInt().Cmp(big.NewInt(0)) == 0 {
 		homestead := b.ChainConfig().IsHomestead(new(big.Int).SetInt64(int64(rpc.PendingBlockNumber)))
 		istanbul := b.ChainConfig().IsIstanbul(new(big.Int).SetInt64(int64(rpc.PendingBlockNumber)))
 		var data []byte


### PR DESCRIPTION
when `eth.estimateGas` is called with any arguments as shown below, the call fails with an error. 
```
> eth.estimateGas({from: eth.accounts(0)})
Error: method handler crashed
    at web3.js:3143:20
    at web3.js:6347:15
    at web3.js:5081:36
    at <anonymous>:1:1
```
This PR fixes the above error. 