### PR TITLE
cmd/geth: exit gradually when there's a failure in PluginManager

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -25,15 +25,14 @@ import (
 	"reflect"
 	"unicode"
 
-	"github.com/naoina/toml"
-	"gopkg.in/urfave/cli.v1"
-
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/dashboard"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+	"github.com/naoina/toml"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var (
@@ -155,13 +154,13 @@ func makeFullNode(ctx *cli.Context) *node.Node {
 		cfg.Eth.OverrideIstanbul = new(big.Int).SetUint64(ctx.GlobalUint64(utils.OverrideIstanbulFlag.Name))
 	}
 
-	// this must be done first to make sure plugin manager is fully up.
-	// any fatal at this point is safe
+	ethChan := utils.RegisterEthService(stack, &cfg.Eth)
+
+	// plugin service must be after eth service so that eth service will be stopped gradually if any of the plugin
+	// fails to start
 	if cfg.Node.Plugins != nil {
 		utils.RegisterPluginService(stack, &cfg.Node, ctx.Bool(utils.PluginSkipVerifyFlag.Name), ctx.Bool(utils.PluginLocalVerifyFlag.Name), ctx.String(utils.PluginPublicKeyFlag.Name))
 	}
-
-	ethChan := utils.RegisterEthService(stack, &cfg.Eth)
 
 	if cfg.Node.IsPermissionEnabled() {
 		utils.RegisterPermissionService(stack)


### PR DESCRIPTION
p2p server handles peer connection before Ethereum service is actually started.
By having PluginManager service (or any service) starts before Ethereum service causing peer
connections being held and geth is unable to exit gradually when
PluginManager service (or any service) returns error.