### PR TITLE
Create separate sub-module for crypto/secp256k1 package

### DIFF
--- a/crypto/secp256k1/go.mod
+++ b/crypto/secp256k1/go.mod
@@ -1,0 +1,3 @@
+module github.com/jpmorganchase/quorum/crypto/secp256k1
+
+go 1.13


### PR DESCRIPTION
Once tagged, this will allow external consumers of the crypto/secp256k1 package to depend only on this package and not the entire quorum codebase