### PR TITLE
private: formalize the usage of common.EncryptedPayloadHash

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -101,6 +101,10 @@ func (eph EncryptedPayloadHash) BytesTypeRef() *hexutil.Bytes {
 	return &b
 }
 
+func EmptyEncryptedPayloadHash(eph EncryptedPayloadHash) bool {
+	return eph == EncryptedPayloadHash{}
+}
+
 // Hash represents the 32 byte Keccak256 hash of arbitrary data.
 type Hash [HashLength]byte
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -214,7 +214,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	publicState := st.state
 	if msg, ok := msg.(PrivateMessage); ok && isQuorum && msg.IsPrivate() {
 		isPrivate = true
-		data, err = private.P.Receive(st.data)
+		data, err = private.P.Receive(common.BytesToEncryptedPayloadHash(st.data))
 		// Increment the public account nonce if:
 		// 1. Tx is private and *not* a participant of the group and either call or create
 		// 2. Tx is private we are part of the group and is a call

--- a/core/state_transition_test.go
+++ b/core/state_transition_test.go
@@ -93,19 +93,19 @@ type StubPrivateTransactionManager struct {
 	responses map[string][]interface{}
 }
 
-func (spm *StubPrivateTransactionManager) Send(data []byte, from string, to []string) ([]byte, error) {
+func (spm *StubPrivateTransactionManager) Send(data []byte, from string, to []string) (common.EncryptedPayloadHash, error) {
+	return common.EncryptedPayloadHash{}, fmt.Errorf("to be implemented")
+}
+
+func (spm *StubPrivateTransactionManager) StoreRaw(data []byte, from string) (common.EncryptedPayloadHash, error) {
+	return common.EncryptedPayloadHash{}, fmt.Errorf("to be implemented")
+}
+
+func (spm *StubPrivateTransactionManager) SendSignedTx(txHash common.EncryptedPayloadHash, to []string) ([]byte, error) {
 	return nil, fmt.Errorf("to be implemented")
 }
 
-func (spm *StubPrivateTransactionManager) StoreRaw(data []byte, from string) ([]byte, error) {
-	return nil, fmt.Errorf("to be implemented")
-}
-
-func (spm *StubPrivateTransactionManager) SendSignedTx(data []byte, to []string) ([]byte, error) {
-	return nil, fmt.Errorf("to be implemented")
-}
-
-func (spm *StubPrivateTransactionManager) Receive(data []byte) ([]byte, error) {
+func (spm *StubPrivateTransactionManager) Receive(txHash common.EncryptedPayloadHash) ([]byte, error) {
 	res := spm.responses["Receive"]
 	if err, ok := res[1].(error); ok {
 		return nil, err

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -549,7 +549,11 @@ func (ec *Client) PreparePrivateTransaction(data []byte, privateFrom string) ([]
 	if ec.pc == nil {
 		return nil, errors.New("missing private transaction manager client configuration")
 	}
-	return ec.pc.StoreRaw(data, privateFrom)
+	encryptedPayloadHash, err := ec.pc.StoreRaw(data, privateFrom)
+	if err != nil {
+		return nil, err
+	}
+	return encryptedPayloadHash.Bytes(), err
 }
 
 func toCallArg(msg ethereum.CallMsg) interface{} {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -346,20 +346,20 @@ func TestClient_PreparePrivateTransaction_whenTypical(t *testing.T) {
 }
 
 func TestClient_PreparePrivateTransaction_whenClientIsConfigured(t *testing.T) {
-	expectedData := []byte("arbitrary data")
+	expectedData := common.BytesToEncryptedPayloadHash([]byte("arbitrary data"))
 	testObject := NewClient(nil)
 	testObject.pc = &privateTransactionManagerStubClient{expectedData}
 
 	actualData, err := testObject.PreparePrivateTransaction([]byte("arbitrary payload"), "arbitrary private from")
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectedData, actualData)
+	assert.Equal(t, expectedData.Bytes(), actualData)
 }
 
 type privateTransactionManagerStubClient struct {
-	expectedData []byte
+	expectedData common.EncryptedPayloadHash
 }
 
-func (s *privateTransactionManagerStubClient) StoreRaw(data []byte, privateFrom string) ([]byte, error) {
+func (s *privateTransactionManagerStubClient) StoreRaw(_ []byte, _ string) (common.EncryptedPayloadHash, error) {
 	return s.expectedData, nil
 }

--- a/ethclient/privateTransactionManagerClient.go
+++ b/ethclient/privateTransactionManagerClient.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type privateTransactionManagerClient interface {
-	StoreRaw(data []byte, privateFrom string) ([]byte, error)
+	StoreRaw(data []byte, privateFrom string) (common.EncryptedPayloadHash, error)
 }
 
 type privateTransactionManagerDefaultClient struct {
@@ -39,33 +41,33 @@ type storeRawResp struct {
 	Key string `json:"key"`
 }
 
-func (pc *privateTransactionManagerDefaultClient) StoreRaw(data []byte, privateFrom string) ([]byte, error) {
+func (pc *privateTransactionManagerDefaultClient) StoreRaw(data []byte, privateFrom string) (common.EncryptedPayloadHash, error) {
 	storeRawReq := &storeRawReq{
 		Payload: base64.StdEncoding.EncodeToString(data),
 		From:    privateFrom,
 	}
 	reqBodyBuf := new(bytes.Buffer)
 	if err := json.NewEncoder(reqBodyBuf).Encode(storeRawReq); err != nil {
-		return nil, err
+		return common.EncryptedPayloadHash{}, err
 	}
 	resp, err := pc.httpClient.Post(pc.rawurl+"/storeraw", "application/json", reqBodyBuf)
 	if err != nil {
-		return nil, fmt.Errorf("unable to invoke /storeraw due to %s", err)
+		return common.EncryptedPayloadHash{}, fmt.Errorf("unable to invoke /storeraw due to %s", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returns %s", resp.Status)
+		return common.EncryptedPayloadHash{}, fmt.Errorf("server returns %s", resp.Status)
 	}
 	// parse response
 	var storeRawResp storeRawResp
 	if err := json.NewDecoder(resp.Body).Decode(&storeRawResp); err != nil {
-		return nil, err
+		return common.EncryptedPayloadHash{}, err
 	}
-	encryptedPayloadHash, err := base64.StdEncoding.DecodeString(storeRawResp.Key)
+	b, err := base64.StdEncoding.DecodeString(storeRawResp.Key)
 	if err != nil {
-		return nil, err
+		return common.EncryptedPayloadHash{}, err
 	}
-	return encryptedPayloadHash, nil
+	return common.BytesToEncryptedPayloadHash(b), nil
 }

--- a/ethclient/privateTransactionManagerClient_test.go
+++ b/ethclient/privateTransactionManagerClient_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +25,7 @@ func TestPrivateTransactionManagerClient_storeRaw(t *testing.T) {
 	key, err := testObject.StoreRaw([]byte("arbitrary payload"), "arbitrary private from")
 
 	assert.NoError(t, err)
-	assert.Equal(t, "arbitrary data", string(key))
+	assert.Equal(t, common.BytesToEncryptedPayloadHash([]byte("arbitrary data")), key)
 }
 
 func newStoreRawServer() *httptest.Server {

--- a/extension/backend.go
+++ b/extension/backend.go
@@ -299,7 +299,7 @@ func (service *PrivacyService) watchForCompletionEvents() error {
 						log.Error("[ptm] service.ptm.Send", "stateDataInHex", hex.EncodeToString(entireStateData[:]), "recipient", recipientPTMKey, "error", err)
 						return
 					}
-					hashofStateDataBase64 := base64.StdEncoding.EncodeToString(hashOfStateData)
+					hashofStateDataBase64 := base64.StdEncoding.EncodeToString(hashOfStateData.Bytes())
 
 					transactor, err := service.managementContractFacade.Transactor(l.Address)
 					if err != nil {

--- a/extension/extension_utilities.go
+++ b/extension/extension_utilities.go
@@ -14,7 +14,7 @@ func generateUuid(contractAddress common.Address, privateFrom string, ptm privat
 	if err != nil {
 		return "", err
 	}
-	return common.BytesToEncryptedPayloadHash(hash).String(), nil
+	return hash.String(), nil
 }
 
 func checkAddressInList(addressToFind common.Address, addressList []common.Address) bool {

--- a/extension/privacyExtension/state_setter.go
+++ b/extension/privacyExtension/state_setter.go
@@ -76,7 +76,7 @@ func (handler *ExtensionHandler) FetchStateData(address common.Address, hash str
 
 func (handler *ExtensionHandler) FetchDataFromPTM(hash string) ([]byte, bool) {
 	ptmHash, _ := base64.StdEncoding.DecodeString(hash)
-	stateData, err := handler.ptm.Receive(ptmHash)
+	stateData, err := handler.ptm.Receive(common.BytesToEncryptedPayloadHash(ptmHash))
 
 	if stateData == nil {
 		log.Error("No state data found in PTM", "ptm hash", hash)
@@ -102,7 +102,7 @@ func (handler *ExtensionHandler) UuidIsOwn(address common.Address, uuid string) 
 		log.Debug("Extension: could not determine if we are sender", "err", err.Error())
 		return false
 	}
-	data, _ := handler.ptm.Receive(encryptedTxHash.Bytes())
+	data, _ := handler.ptm.Receive(encryptedTxHash)
 	retrievedAddress := common.BytesToAddress(data)
 	if !bytes.Equal(retrievedAddress.Bytes(), address.Bytes()) {
 		log.Error("Extension: wrong address in retrieved UUID")

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -358,7 +358,7 @@ func (t *Transaction) PrivateInputData(ctx context.Context) (*hexutil.Bytes, err
 		return &hexutil.Bytes{}, err
 	}
 	if tx.IsPrivate() {
-		privateInputData, err := private.P.Receive(tx.Data())
+		privateInputData, err := private.P.Receive(common.BytesToEncryptedPayloadHash(tx.Data()))
 		if err != nil || tx == nil {
 			return &hexutil.Bytes{}, err
 		}

--- a/private/engine/notinuse/notInUsePrivateTxManager.go
+++ b/private/engine/notinuse/notInUsePrivateTxManager.go
@@ -20,19 +20,19 @@ func (ptm *PrivateTransactionManager) GetParticipants(txHash common.EncryptedPay
 	panic("implement me")
 }
 
-func (ptm *PrivateTransactionManager) Send(data []byte, from string, to []string) ([]byte, error) {
+func (ptm *PrivateTransactionManager) Send(data []byte, from string, to []string) (common.EncryptedPayloadHash, error) {
+	return common.EncryptedPayloadHash{}, ErrPrivateTxManagerNotInUse
+}
+
+func (ptm *PrivateTransactionManager) StoreRaw(data []byte, from string) (common.EncryptedPayloadHash, error) {
+	return common.EncryptedPayloadHash{}, ErrPrivateTxManagerNotInUse
+}
+
+func (ptm *PrivateTransactionManager) SendSignedTx(txHash common.EncryptedPayloadHash, to []string) ([]byte, error) {
 	return nil, ErrPrivateTxManagerNotInUse
 }
 
-func (ptm *PrivateTransactionManager) StoreRaw(data []byte, from string) ([]byte, error) {
-	return nil, ErrPrivateTxManagerNotInUse
-}
-
-func (ptm *PrivateTransactionManager) SendSignedTx(data []byte, to []string) ([]byte, error) {
-	return nil, ErrPrivateTxManagerNotInUse
-}
-
-func (ptm *PrivateTransactionManager) Receive(data []byte) ([]byte, error) {
+func (ptm *PrivateTransactionManager) Receive(txHash common.EncryptedPayloadHash) ([]byte, error) {
 	//error not thrown here, acts as though no private data to fetch
 	return nil, nil
 }

--- a/private/engine/notinuse/notInUsePrivateTxManager_test.go
+++ b/private/engine/notinuse/notInUsePrivateTxManager_test.go
@@ -3,6 +3,7 @@ package notinuse
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +33,7 @@ func TestStoreRawReturnsError(t *testing.T) {
 func TestReceiveReturnsError(t *testing.T) {
 	ptm := &PrivateTransactionManager{}
 
-	_, err := ptm.Receive([]byte{})
+	_, err := ptm.Receive(common.EncryptedPayloadHash{})
 
 	assert.Nil(t, err, "got unexpected error in 'receive'")
 }
@@ -40,7 +41,7 @@ func TestReceiveReturnsError(t *testing.T) {
 func TestSendSignedTxReturnsError(t *testing.T) {
 	ptm := &PrivateTransactionManager{}
 
-	_, err := ptm.SendSignedTx([]byte{}, []string{})
+	_, err := ptm.SendSignedTx(common.EncryptedPayloadHash{}, []string{})
 
 	assert.Equal(t, err, ErrPrivateTxManagerNotInUse, "got wrong error in 'SendSignedTx'")
 }

--- a/private/private.go
+++ b/private/private.go
@@ -10,11 +10,12 @@ import (
 	"github.com/ethereum/go-ethereum/private/privatetransactionmanager"
 )
 
+// Interacting with Private Transaction Manager APIs
 type PrivateTransactionManager interface {
-	Send(data []byte, from string, to []string) ([]byte, error)
-	StoreRaw(data []byte, from string) ([]byte, error)
-	SendSignedTx(data []byte, to []string) ([]byte, error)
-	Receive(data []byte) ([]byte, error)
+	Send(data []byte, from string, to []string) (common.EncryptedPayloadHash, error)
+	StoreRaw(data []byte, from string) (common.EncryptedPayloadHash, error)
+	SendSignedTx(txHash common.EncryptedPayloadHash, to []string) ([]byte, error)
+	Receive(txHash common.EncryptedPayloadHash) ([]byte, error)
 
 	IsSender(txHash common.EncryptedPayloadHash) (bool, error)
 	GetParticipants(txHash common.EncryptedPayloadHash) ([]string, error)

--- a/private/privatetransactionmanager/tx_manager.go
+++ b/private/privatetransactionmanager/tx_manager.go
@@ -15,46 +15,50 @@ type PrivateTransactionManager struct {
 	c    *gocache.Cache
 }
 
-func (g *PrivateTransactionManager) Send(data []byte, from string, to []string) (out []byte, err error) {
-	out, err = g.node.SendPayload(data, from, to)
+func (g *PrivateTransactionManager) Send(data []byte, from string, to []string) (out common.EncryptedPayloadHash, err error) {
+	var b []byte
+	b, err = g.node.SendPayload(data, from, to)
 	if err != nil {
-		return nil, err
+		return common.EncryptedPayloadHash{}, err
 	}
-	g.c.Set(string(out), data, cache.DefaultExpiration)
+	g.c.Set(string(b), data, cache.DefaultExpiration)
+	out = common.BytesToEncryptedPayloadHash(b)
+	return
+}
+
+func (g *PrivateTransactionManager) StoreRaw(data []byte, from string) (out common.EncryptedPayloadHash, err error) {
+	var b []byte
+	b, err = g.node.StorePayload(data, from)
+	if err != nil {
+		return common.EncryptedPayloadHash{}, err
+	}
+	g.c.Set(string(b), data, cache.DefaultExpiration)
+	out = common.BytesToEncryptedPayloadHash(b)
 	return out, nil
 }
 
-func (g *PrivateTransactionManager) StoreRaw(data []byte, from string) (out []byte, err error) {
-	out, err = g.node.StorePayload(data, from)
-	if err != nil {
-		return nil, err
-	}
-	g.c.Set(string(out), data, cache.DefaultExpiration)
-	return out, nil
-}
-
-func (g *PrivateTransactionManager) SendSignedTx(data []byte, to []string) (out []byte, err error) {
-	out, err = g.node.SendSignedPayload(data, to)
+func (g *PrivateTransactionManager) SendSignedTx(txHash common.EncryptedPayloadHash, to []string) (out []byte, err error) {
+	out, err = g.node.SendSignedPayload(txHash.Bytes(), to)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (g *PrivateTransactionManager) Receive(data []byte) ([]byte, error) {
-	if len(data) == 0 {
-		return data, nil
+func (g *PrivateTransactionManager) Receive(txHash common.EncryptedPayloadHash) ([]byte, error) {
+	if common.EmptyEncryptedPayloadHash(txHash) {
+		return []byte{}, nil
 	}
 	// Ignore this error since not being a recipient of
 	// a payload isn't an error.
 	// TODO: Return an error if it's anything OTHER than
 	// 'you are not a recipient.'
-	dataStr := string(data)
+	dataStr := string(txHash.Bytes())
 	x, found := g.c.Get(dataStr)
 	if found {
 		return x.([]byte), nil
 	}
-	pl, _ := g.node.ReceivePayload(data)
+	pl, _ := g.node.ReceivePayload(txHash.Bytes())
 	g.c.Set(dataStr, pl, cache.DefaultExpiration)
 	return pl, nil
 }


### PR DESCRIPTION
`PrivateTransactionManager` interface methods represent API interaction with a private transaction manager. Using `common.EncryptedPayloadHash` enhances the understandability.