### PR TITLE
[WIP] Make Raft id deterministic, remove  required `--raftjoinexisting $raftId`

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -158,6 +158,7 @@ var (
 		utils.EnableNodePermissionFlag,
 		utils.RaftModeFlag,
 		utils.RaftBlockTimeFlag,
+		utils.RaftJoinExistingFlag,
 		utils.RaftPortFlag,
 		utils.RaftDNSEnabledFlag,
 		utils.EmitCheckpointsFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -158,7 +158,6 @@ var (
 		utils.EnableNodePermissionFlag,
 		utils.RaftModeFlag,
 		utils.RaftBlockTimeFlag,
-		utils.RaftJoinExistingFlag,
 		utils.RaftPortFlag,
 		utils.RaftDNSEnabledFlag,
 		utils.EmitCheckpointsFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -292,7 +292,6 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: []cli.Flag{
 			utils.RaftModeFlag,
 			utils.RaftBlockTimeFlag,
-			utils.RaftJoinExistingFlag,
 			utils.RaftPortFlag,
 			utils.RaftDNSEnabledFlag,
 		},

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -293,6 +293,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RaftModeFlag,
 			utils.RaftBlockTimeFlag,
 			utils.RaftPortFlag,
+			utils.RaftJoinExistingFlag,
 			utils.RaftDNSEnabledFlag,
 		},
 	},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1841,6 +1841,7 @@ func RegisterPermissionService(stack *node.Node) {
 func RegisterRaftService(stack *node.Node, ctx *cli.Context, nodeCfg *node.Config, ethChan chan *eth.Ethereum) {
 	blockTimeMillis := ctx.GlobalInt(RaftBlockTimeFlag.Name)
 	datadir := ctx.GlobalString(DataDirFlag.Name)
+	// TODO: libby make this a boolean or remove it.
 	joinExistingId := ctx.GlobalInt(RaftJoinExistingFlag.Name)
 	useDns := ctx.GlobalBool(RaftDNSEnabledFlag.Name)
 	raftPort := uint16(ctx.GlobalInt(RaftPortFlag.Name))
@@ -1851,37 +1852,18 @@ func RegisterRaftService(stack *node.Node, ctx *cli.Context, nodeCfg *node.Confi
 		blockTimeNanos := time.Duration(blockTimeMillis) * time.Millisecond
 		peers := nodeCfg.StaticNodes()
 
-		var myId uint16
 		var joinExisting bool
 
 		if joinExistingId > 0 {
-			myId = uint16(joinExistingId)
 			joinExisting = true
 		} else if len(peers) == 0 {
 			Fatalf("Raft-based consensus requires either (1) an initial peers list (in static-nodes.json) including this enode hash (%v), or (2) the flag --raftjoinexisting RAFT_ID, where RAFT_ID has been issued by an existing cluster member calling `raft.addPeer(ENODE_ID)` with an enode ID containing this node's enode hash.", strId)
-		} else {
-			peerIds := make([]string, len(peers))
-
-			for peerIdx, peer := range peers {
-				if !peer.HasRaftPort() {
-					Fatalf("raftport querystring parameter not specified in static-node enode ID: %v. please check your static-nodes.json file.", peer.String())
-				}
-
-				peerId := peer.ID().String()
-				peerIds[peerIdx] = peerId
-				if peerId == strId {
-					myId = uint16(peerIdx) + 1
-				}
-			}
-
-			if myId == 0 {
-				Fatalf("failed to find local enode ID (%v) amongst peer IDs: %v", strId, peerIds)
-			}
 		}
 
 		ethereum := <-ethChan
 		ethChan <- ethereum
-		return raft.New(ctx, ethereum.BlockChain().Config(), myId, raftPort, joinExisting, blockTimeNanos, ethereum, peers, datadir, useDns)
+
+		return raft.New(ctx, ethereum.BlockChain().Config(), raftPort, joinExisting, blockTimeNanos, ethereum, peers, datadir, useDns)
 	}); err != nil {
 		Fatalf("Failed to register the Raft service: %v", err)
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1862,7 +1862,7 @@ func RegisterRaftService(stack *node.Node, ctx *cli.Context, nodeCfg *node.Confi
 
 		ethereum := <-ethChan
 		ethChan <- ethereum
-        // myId joinExisting
+		// myId joinExisting
 		return raft.New(ctx, ethereum.BlockChain().Config(), myId, joinExisting, raftPort, blockTimeNanos, ethereum, peers, datadir, useDns)
 	}); err != nil {
 		Fatalf("Failed to register the Raft service: %v", err)

--- a/permission/permission.go
+++ b/permission/permission.go
@@ -595,7 +595,8 @@ func (p *PermissionCtrl) disconnectNode(enodeId string) {
 			//get the raftId for the given enodeId
 			raftId, err := raftApi.GetRaftId(enodeId)
 			if err == nil {
-				raftApi.RemovePeer(raftId)
+				raftIdStr := raft.RaftIdToString(raftId)
+				raftApi.RemovePeer(raftIdStr)
 			} else {
 				log.Error("failed to get raft id", "err", err, "enodeId", enodeId)
 			}

--- a/raft/api.go
+++ b/raft/api.go
@@ -123,14 +123,14 @@ func (s *PublicRaftAPI) Cluster() ([]ClusterInfo, error) {
 		if !noLeader {
 			if a.RaftId == leaderAddr.RaftId {
 				role = "minter"
-			} else if s.raftService.raftProtocolManager.isLearner(a.RaftId) {
+			} else if s.raftService.raftProtocolManager.isLearner(uint64(a.RaftId)) {
 				role = "learner"
-			} else if s.raftService.raftProtocolManager.isVerifier(a.RaftId) {
+			} else if s.raftService.raftProtocolManager.isVerifier(uint64(a.RaftId)) {
 				role = "verifier"
 			}
 		}
 		//log.Info("Cluster RaftId is: ", "a.RaftId", a.RaftId, "aJS.RaftId", aJS.RaftId)
-		clustInfo[i] = ClusterInfo{*aJS, role, s.checkIfNodeIsActive(a.RaftId)}
+		clustInfo[i] = ClusterInfo{*aJS, role, s.checkIfNodeIsActive(uint64(a.RaftId))}
 	}
 	return clustInfo, nil
 }

--- a/raft/api.go
+++ b/raft/api.go
@@ -38,7 +38,7 @@ func (s *PublicRaftAPI) Role() string {
 
 // helper function to check if self node is part of cluster
 func (s *PublicRaftAPI) checkIfNodeInCluster() error {
-	if s.raftService.raftProtocolManager.IsIDRemoved(uint64(s.raftService.raftProtocolManager.raftId)) {
+	if s.raftService.raftProtocolManager.IsIDRemoved(s.raftService.raftProtocolManager.raftId) {
 		return errors.New("node not part of raft cluster. operations not allowed")
 	}
 	return nil

--- a/raft/api.go
+++ b/raft/api.go
@@ -2,8 +2,9 @@ package raft
 
 import (
 	"errors"
-	"github.com/coreos/etcd/pkg/types"
 	"strconv"
+
+	"github.com/coreos/etcd/pkg/types"
 )
 
 type RaftNodeInfo struct {

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -40,7 +40,7 @@ type RaftService struct {
 
 // When we create a new Raft ProtocolManager this happens before we have access to the node id. The raftId is derived from the
 // node id, so at the time of creation do not know the raft id yet.
-func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftPort uint16, blockTime time.Duration, e *eth.Ethereum, startPeers []*enode.Node, datadir string, useDns bool) (*RaftService, error) {
+func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftId uint64, raftjoinExisting bool, raftPort uint16, blockTime time.Duration, e *eth.Ethereum, startPeers []*enode.Node, datadir string, useDns bool) (*RaftService, error) {
 	service := &RaftService{
 		eventMux:         ctx.EventMux,
 		chainDb:          e.ChainDb(),
@@ -56,7 +56,7 @@ func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftPort uin
 	service.minter = newMinter(chainConfig, service, blockTime)
 
 	var err error
-	if service.raftProtocolManager, err = NewProtocolManager(raftPort, service.blockchain, service.eventMux, startPeers, datadir, service.minter, service.downloader, useDns); err != nil {
+	if service.raftProtocolManager, err = NewProtocolManager(raftId, raftPort, service.blockchain, service.eventMux, startPeers, raftjoinExisting, datadir, service.minter, service.downloader, useDns); err != nil {
 		return nil, err
 	}
 

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -40,7 +40,7 @@ type RaftService struct {
 
 // When we create a new Raft ProtocolManager this happens before we have access to the node id. The raftId is derived from the
 // node id, so at the time of creation do not know the raft id yet.
-func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftPort uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*enode.Node, datadir string, useDns bool) (*RaftService, error) {
+func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftPort uint16, blockTime time.Duration, e *eth.Ethereum, startPeers []*enode.Node, datadir string, useDns bool) (*RaftService, error) {
 	service := &RaftService{
 		eventMux:         ctx.EventMux,
 		chainDb:          e.ChainDb(),
@@ -56,7 +56,7 @@ func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftPort uin
 	service.minter = newMinter(chainConfig, service, blockTime)
 
 	var err error
-	if service.raftProtocolManager, err = NewProtocolManager(raftPort, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter, service.downloader, useDns); err != nil {
+	if service.raftProtocolManager, err = NewProtocolManager(raftPort, service.blockchain, service.eventMux, startPeers, datadir, service.minter, service.downloader, useDns); err != nil {
 		return nil, err
 	}
 

--- a/raft/backend.go
+++ b/raft/backend.go
@@ -38,7 +38,9 @@ type RaftService struct {
 	calcGasLimitFunc func(block *types.Block) uint64
 }
 
-func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftId, raftPort uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*enode.Node, datadir string, useDns bool) (*RaftService, error) {
+// When we create a new Raft ProtocolManager this happens before we have access to the node id. The raftId is derived from the
+// node id, so at the time of creation do not know the raft id yet.
+func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftPort uint16, joinExisting bool, blockTime time.Duration, e *eth.Ethereum, startPeers []*enode.Node, datadir string, useDns bool) (*RaftService, error) {
 	service := &RaftService{
 		eventMux:         ctx.EventMux,
 		chainDb:          e.ChainDb(),
@@ -54,7 +56,7 @@ func New(ctx *node.ServiceContext, chainConfig *params.ChainConfig, raftId, raft
 	service.minter = newMinter(chainConfig, service, blockTime)
 
 	var err error
-	if service.raftProtocolManager, err = NewProtocolManager(raftId, raftPort, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter, service.downloader, useDns); err != nil {
+	if service.raftProtocolManager, err = NewProtocolManager(raftPort, service.blockchain, service.eventMux, startPeers, joinExisting, datadir, service.minter, service.downloader, useDns); err != nil {
 		return nil, err
 	}
 

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -133,6 +133,11 @@ func NewProtocolManager(raftPort uint16, blockchain *core.BlockChain, mux *event
 	return manager, nil
 }
 
+// Used for testing only
+func (pm *ProtocolManager) setRaftId(raftId uint64) {
+	pm.raftId = raftId
+}
+
 func (pm *ProtocolManager) Start(p2pServer *p2p.Server) {
 	log.Info("starting raft protocol handler")
 
@@ -323,7 +328,7 @@ func (pm *ProtocolManager) ProposeNewPeer(enodeId string, isLearner bool) (uint6
 	}
 	if pm.isRaftIdInCluster(raftId) { // TODO: Libby change this, if it is in the cluster return the Id and a bool.
 		log.Error("raftId is already in cluster", "raft id", raftId)
-		return 0, fmt.Errorf("raftId is already in cluster", "raft id", raftId)
+		return 0, fmt.Errorf("raftId is already in cluster raft id [%d]", raftId)
 	}
 
 	// we are proposing a node, that may have been previously remove, if it was previously removed, allow it to be added again.

--- a/raft/handler.go
+++ b/raft/handler.go
@@ -105,7 +105,7 @@ func NewProtocolManager(raftPort uint16, blockchain *core.BlockChain, mux *event
 	manager := &ProtocolManager{
 		bootstrapNodes:      bootstrapNodes,
 		peers:               make(map[uint64]*Peer),
-		leader:              uint64(etcdRaft.None),
+		leader:              etcdRaft.None,
 		removedPeers:        mapset.NewSet(),
 		blockchain:          blockchain,
 		eventMux:            mux,

--- a/raft/handler_test.go
+++ b/raft/handler_test.go
@@ -175,7 +175,7 @@ func startRaftNode(id, port uint16, tmpWorkingDir string, key *ecdsa.PrivateKey,
 		return nil, err
 	}
 
-	s, err := New(ctx, params.QuorumTestChainConfig, port, 100*time.Millisecond, e, nodes, datadir, false)
+	s, err := New(ctx, params.QuorumTestChainConfig, uint64(id), false, port, 100*time.Millisecond, e, nodes, datadir, false)
 	if err != nil {
 		return nil, err
 	}

--- a/raft/handler_test.go
+++ b/raft/handler_test.go
@@ -175,7 +175,7 @@ func startRaftNode(id, port uint16, tmpWorkingDir string, key *ecdsa.PrivateKey,
 		return nil, err
 	}
 
-	s, err := New(ctx, params.QuorumTestChainConfig, id, port, false, 100*time.Millisecond, e, nodes, datadir, false)
+	s, err := New(ctx, params.QuorumTestChainConfig, port, 100*time.Millisecond, e, nodes, datadir, false)
 	if err != nil {
 		return nil, err
 	}

--- a/raft/minter.go
+++ b/raft/minter.go
@@ -429,7 +429,7 @@ func (minter *minter) buildExtraSeal(headerHash common.Hash) []byte {
 	}
 
 	//build the extraSeal struct
-	raftIdString := hexutil.EncodeUint64(uint64(minter.eth.raftProtocolManager.raftId))
+	raftIdString := hexutil.EncodeUint64(minter.eth.raftProtocolManager.raftId)
 
 	extra := extraSeal{
 		RaftId:    []byte(raftIdString[2:]), //remove the 0x prefix

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -202,7 +202,7 @@ func getRaftId(t *testing.T, enodeId string) uint64 {
 	if err != nil {
 		t.Fatalf("Unable convert enode id: %s to raft Id. error: %s", enodeId, err.Error())
 	}
-	return raftId
+	return uint64(raftId)
 }
 
 func peerList(url string) (error, []*enode.Node) {

--- a/raft/minter_test.go
+++ b/raft/minter_test.go
@@ -19,10 +19,25 @@ import (
 )
 
 const TEST_URL = "enode://3d9ca5956b38557aba991e31cf510d4df641dce9cc26bfeb7de082f0c07abb6ede3a58410c8f249dabeecee4ad3979929ac4c7c496ad20b8cfdd061b7401b4f5@127.0.0.1:21003?discport=0&raftport=50404"
+const ENODE_URL_NODE1 = "enode://ac6b1096ca56b9f6d004b779ae3728bf83f8e22453404cc3cef16a3d9b96608bc67c4b30db88e0a5a6c6390213f7acbe1153ff6d23ce57380104288ae19373ef@quorum-node1:30303?discport=0&raftport=50401"
+const ENODE_URL_NODE2 = "enode://0ba6b9f606a43a95edc6247cdb1c1e105145817be7bcafd6b2c0ba15d58145f0dc1a194f70ba73cd6f4cdd6864edc7687f311254c7555cc32e4d45aeb1b80416@quorum-node2:30303?discport=0&raftport=50401"
+const ENODE_URL_NODE3 = "enode://579f786d4e2830bbcc02815a27e8a9bacccc9605df4dc6f20bcc1a6eb391e7225fff7cb83e5b4ecd1f3a94d8b733803f2f66b7e871961e7b029e22c155c3a778@quorum-node3:30303?discport=0&raftport=50401"
+const ENODE_URL_NODE4 = "enode://3d9ca5956b38557aba991e31cf510d4df641dce9cc26bfeb7de082f0c07abb6ede3a58410c8f249dabeecee4ad3979929ac4c7c496ad20b8cfdd061b7401b4f5@quorum-node4:30303?discport=0&raftport=50401"
+const ENODE_URL_NODE5 = "enode://3701f007bfa4cb26512d7df18e6bbd202e8484a6e11d387af6e482b525fa25542d46ff9c99db87bd419b980c24a086117a397f6d8f88e74351b41693880ea0cb@quorum-node5:30303?discport=0&raftport=50401"
+const ENODE_URL_NODE6 = "enode://eacaa74c4b0e7a9e12d2fe5fee6595eda841d6d992c35dbbcc50fcee4aa86dfbbdeff7dc7e72c2305d5a62257f82737a8cffc80474c15c611c037f52db1a3a7b@quorum-node6:30303?discport=0&raftport=50401"
+const ENODE_URL_NODE7 = "enode://239c1f044a2b03b6c4713109af036b775c5418fe4ca63b04b1ce00124af00ddab7cc088fc46020cdc783b6207efe624551be4c06a994993d8d70f684688fb7cf@quorum-node7:30303?discport=0&raftport=50401"
+
+const ENODE_ID_NODE1 = "ac6b1096ca56b9f6d004b779ae3728bf83f8e22453404cc3cef16a3d9b96608bc67c4b30db88e0a5a6c6390213f7acbe1153ff6d23ce57380104288ae19373ef"
+const ENODE_ID_NODE2 = "0ba6b9f606a43a95edc6247cdb1c1e105145817be7bcafd6b2c0ba15d58145f0dc1a194f70ba73cd6f4cdd6864edc7687f311254c7555cc32e4d45aeb1b80416"
+const ENODE_ID_NODE3 = "579f786d4e2830bbcc02815a27e8a9bacccc9605df4dc6f20bcc1a6eb391e7225fff7cb83e5b4ecd1f3a94d8b733803f2f66b7e871961e7b029e22c155c3a778"
+const ENODE_ID_NODE4 = "3d9ca5956b38557aba991e31cf510d4df641dce9cc26bfeb7de082f0c07abb6ede3a58410c8f249dabeecee4ad3979929ac4c7c496ad20b8cfdd061b7401b4f5"
+const ENODE_ID_NODE5 = "3701f007bfa4cb26512d7df18e6bbd202e8484a6e11d387af6e482b525fa25542d46ff9c99db87bd419b980c24a086117a397f6d8f88e74351b41693880ea0cb"
+const ENODE_ID_NODE6 = "eacaa74c4b0e7a9e12d2fe5fee6595eda841d6d992c35dbbcc50fcee4aa86dfbbdeff7dc7e72c2305d5a62257f82737a8cffc80474c15c611c037f52db1a3a7b"
+const ENODE_ID_NODE7 = "239c1f044a2b03b6c4713109af036b775c5418fe4ca63b04b1ce00124af00ddab7cc088fc46020cdc783b6207efe624551be4c06a994993d8d70f684688fb7cf"
 
 func TestSignHeader(t *testing.T) {
 	//create only what we need to test the seal
-	var testRaftId uint16 = 5
+	testRaftId := getRaftId(t, ENODE_ID_NODE5) // 5
 	config := &node.Config{Name: "unit-test", DataDir: ""}
 
 	nodeKey := config.NodeKey()
@@ -76,16 +91,18 @@ func TestSignHeader(t *testing.T) {
 }
 
 func TestAddLearner_whenTypical(t *testing.T) {
-
-	raftService := newTestRaftService(t, 1, []uint64{1}, []uint64{})
+	raftIdNode1 := getRaftId(t, ENODE_ID_NODE1)
+	raftService := newTestRaftService(t, []uint64{raftIdNode1}, []uint64{})
+	raftService.raftProtocolManager.setRaftId(raftIdNode1)
 
 	propPeer := func() {
 		raftid, err := raftService.raftProtocolManager.ProposeNewPeer(TEST_URL, true)
+		raftService.raftProtocolManager.setRaftId(raftid)
 		if err != nil {
 			t.Errorf("propose new peer failed %v\n", err)
 		}
-		if raftid != raftService.raftProtocolManager.raftId+1 {
-			t.Errorf("1. wrong raft id. expected %d got %d\n", raftService.raftProtocolManager.raftId+1, raftid)
+		if raftid != raftService.raftProtocolManager.raftId {
+			t.Errorf("1. wrong raft id. expected %d got %d\n", raftService.raftProtocolManager.raftId, raftid)
 		}
 	}
 	go propPeer()
@@ -94,8 +111,8 @@ func TestAddLearner_whenTypical(t *testing.T) {
 		if confChange.Type != raftpb.ConfChangeAddLearnerNode {
 			t.Errorf("expected ConfChangeAddLearnerNode but got %s", confChange.Type.String())
 		}
-		if uint16(confChange.NodeID) != raftService.raftProtocolManager.raftId+1 {
-			t.Errorf("2. wrong raft id. expected %d got %d\n", raftService.raftProtocolManager.raftId+1, uint16(confChange.NodeID))
+		if confChange.NodeID != raftService.raftProtocolManager.raftId {
+			t.Errorf("2. wrong raft id. expected %d got %d\n", raftService.raftProtocolManager.raftId, confChange.NodeID)
 		}
 	case <-time.After(time.Millisecond * 200):
 		t.Errorf("add learner conf change not received")
@@ -103,10 +120,15 @@ func TestAddLearner_whenTypical(t *testing.T) {
 }
 
 func TestPromoteLearnerToPeer_whenTypical(t *testing.T) {
-	learnerRaftId := uint16(3)
-	raftService := newTestRaftService(t, 2, []uint64{2}, []uint64{uint64(learnerRaftId)})
+	// TODO: get enode id for node
+	//learnerRaftId := uint16(3)
+	raftIdLearner3 := getRaftId(t, ENODE_ID_NODE3)
+	raftIdNode2 := getRaftId(t, ENODE_ID_NODE2)
+	raftService := newTestRaftService(t, []uint64{raftIdNode2}, []uint64{raftIdLearner3})
+	raftService.raftProtocolManager.setRaftId(raftIdNode2)
+
 	promoteToPeer := func() {
-		ok, err := raftService.raftProtocolManager.PromoteToPeer(learnerRaftId)
+		ok, err := raftService.raftProtocolManager.PromoteToPeer(raftIdLearner3)
 		if err != nil || !ok {
 			t.Errorf("promote learner to peer failed %v\n", err)
 		}
@@ -117,8 +139,8 @@ func TestPromoteLearnerToPeer_whenTypical(t *testing.T) {
 		if confChange.Type != raftpb.ConfChangeAddNode {
 			t.Errorf("expected ConfChangeAddNode but got %s", confChange.Type.String())
 		}
-		if uint16(confChange.NodeID) != learnerRaftId {
-			t.Errorf("2. wrong raft id. expected %d got %d\n", learnerRaftId, uint16(confChange.NodeID))
+		if confChange.NodeID != raftIdLearner3 {
+			t.Errorf("2. wrong raft id. expected %d got %d\n", raftIdLearner3, confChange.NodeID)
 		}
 	case <-time.After(time.Millisecond * 200):
 		t.Errorf("add learner conf change not received")
@@ -126,9 +148,10 @@ func TestPromoteLearnerToPeer_whenTypical(t *testing.T) {
 }
 
 func TestAddLearnerOrPeer_fromLearner(t *testing.T) {
-
-	raftService := newTestRaftService(t, 3, []uint64{2}, []uint64{3})
-
+	raftIdNode2 := getRaftId(t, ENODE_ID_NODE2)
+	raftIdLearner3 := getRaftId(t, ENODE_ID_NODE3)
+	raftService := newTestRaftService(t, []uint64{raftIdNode2}, []uint64{raftIdLearner3})
+	raftService.raftProtocolManager.setRaftId(raftIdLearner3)
 	_, err := raftService.raftProtocolManager.ProposeNewPeer(TEST_URL, true)
 
 	if err == nil {
@@ -152,10 +175,13 @@ func TestAddLearnerOrPeer_fromLearner(t *testing.T) {
 }
 
 func TestPromoteLearnerToPeer_fromLearner(t *testing.T) {
-	learnerRaftId := uint16(3)
-	raftService := newTestRaftService(t, 2, []uint64{1}, []uint64{2, uint64(learnerRaftId)})
+	raftIdNode1 := getRaftId(t, ENODE_ID_NODE1)
+	raftIdNode2 := getRaftId(t, ENODE_ID_NODE2)
+	raftIdLearner3 := getRaftId(t, ENODE_ID_NODE3)
+	raftService := newTestRaftService(t, []uint64{raftIdNode1}, []uint64{raftIdNode2, raftIdLearner3})
+	raftService.raftProtocolManager.setRaftId(raftIdNode2)
 
-	_, err := raftService.raftProtocolManager.PromoteToPeer(learnerRaftId)
+	_, err := raftService.raftProtocolManager.PromoteToPeer(raftIdLearner3)
 
 	if err == nil {
 		t.Errorf("learner should not be allowed to promote to peer")
@@ -171,6 +197,14 @@ func enodeId(id string, ip string, raftPort int) string {
 	return fmt.Sprintf("enode://%s@%s?discport=0&raftport=%d", id, ip, raftPort)
 }
 
+func getRaftId(t *testing.T, enodeId string) uint64 {
+	raftId, err := nodeIdToRaftId(enodeId)
+	if err != nil {
+		t.Fatalf("Unable convert enode id: %s to raft Id. error: %s", enodeId, err.Error())
+	}
+	return raftId
+}
+
 func peerList(url string) (error, []*enode.Node) {
 	var nodes []*enode.Node
 	node, err := enode.ParseV4(url)
@@ -181,7 +215,7 @@ func peerList(url string) (error, []*enode.Node) {
 	return nil, nodes
 }
 
-func newTestRaftService(t *testing.T, raftId uint16, nodes []uint64, learners []uint64) *RaftService {
+func newTestRaftService(t *testing.T, nodes []uint64, learners []uint64) *RaftService {
 	//create only what we need to test add learner node
 	config := &node.Config{Name: "unit-test", DataDir: ""}
 	nodeKey := config.NodeKey()
@@ -192,7 +226,6 @@ func newTestRaftService(t *testing.T, raftId uint16, nodes []uint64, learners []
 		t.Errorf("getting peers failed %v", err)
 	}
 	raftProtocolManager := &ProtocolManager{
-		raftId:              raftId,
 		bootstrapNodes:      peers,
 		confChangeProposalC: make(chan raftpb.ConfChange),
 		removedPeers:        mapset.NewSet(),

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -117,12 +117,16 @@ func (addr *Address) toBytes() []byte {
 }
 
 func bytesToAddress(input []byte) *Address {
+	log.Println(fmt.Sprintf("Libby [bytesToAddress] let's see the decoding " ))
 	// try the new format first
 	addr := new(Address)
 	streamNew := rlp.NewStream(bytes.NewReader(input), 0)
 	if err := streamNew.Decode(addr); err == nil {
 		return addr
+	} else {
+		log.Println(fmt.Sprintf("Libby [streamNew] had error decoding add error [%v]", err))
 	}
+	log.Println("Libby made it passed the new stream")
 
 	// else try the old format
 	var temp struct {
@@ -136,6 +140,8 @@ func bytesToAddress(input []byte) *Address {
 	streamOld := rlp.NewStream(bytes.NewReader(input), 0)
 	if err := streamOld.Decode(&temp); err != nil {
 		log.Fatalf("failed to RLP-decode Address: %v", err)
+	} else {
+		log.Println(fmt.Sprintf("Libby [streamOld] had error decoding add error [%v]", err))
 	}
 
 	return &Address{

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -15,7 +15,7 @@ import (
 // or `enode.Node`.
 // As NodeId is mainly used to derive the `ecdsa.pubkey` to build `enode.Node` it is kept as [64]byte instead of ID [32]byte used by `enode.Node`.
 type Address struct {
-	RaftId   uint16        `json:"raftId"`
+	RaftId   uint64        `json:"raftId"`
 	NodeId   enode.EnodeID `json:"nodeId"`
 	Ip       net.IP        `json:"-"`
 	P2pPort  enr.TCP       `json:"p2pPort"`
@@ -27,13 +27,45 @@ type Address struct {
 	Rest []rlp.RawValue `json:"-" rlp:"tail"`
 }
 
+// We use this as a wrapper when displaying the Address in Javascript, as a Number in Javascript cannot not represent a uint64.
+// To fix the JS rendering issue, a string is used instead of an uint64 for the raftId in Javascript.
+// https://2ality.com/2012/04/number-encoding.html#:~:text=JavaScript%20numbers&text=JavaScript%20uses%20binary64%20or%20double,binary%20format%2C%20in%2064%20bits.
+// javascript: As the former name indicates, numbers are stored in a binary format, in 64 bits. These bits are allotted as follows:
+// The fraction occupies bits 0 to 51, the exponent occupies bits 52 to 62, the sign occupies bit 63.
+type AddressJS struct {
+	RaftId   string        `json:"raftId"`
+	NodeId   enode.EnodeID `json:"nodeId"`
+	Ip       net.IP        `json:"-"`
+	P2pPort  enr.TCP       `json:"p2pPort"`
+	RaftPort enr.RaftPort  `json:"raftPort"`
+
+	Hostname string `json:"hostname"`
+
+	// Ignore additional fields (for forward compatibility).
+	Rest []rlp.RawValue `json:"-" rlp:"tail"`
+}
+
+func newAddressJS(a *Address) *AddressJS {
+	return &AddressJS{
+		RaftId:   fmt.Sprintf("%8d", a.RaftId),
+		NodeId:   a.NodeId,
+		Ip:       a.Ip,
+		P2pPort:  a.P2pPort,
+		RaftPort: a.RaftPort,
+		Hostname: a.Hostname,
+	}
+}
+
+// ClusterInfo is used to display the cluster information in Javascript,
+// use the AddressJS instead of Address to display the raftId properly, raftId in Javascipt should be represented as
+// a string, as uint64 (go) and Number (js) are not compatible.
 type ClusterInfo struct {
-	Address
+	AddressJS
 	Role       string `json:"role"`
 	NodeActive bool   `json:"nodeActive"`
 }
 
-func newAddress(raftId uint16, raftPort int, node *enode.Node, useDns bool) *Address {
+func newAddress(raftId uint64, raftPort int, node *enode.Node, useDns bool) *Address {
 	// derive 64 byte nodeID from 128 byte enodeID
 	id, err := enode.RaftHexID(node.EnodeID())
 	if err != nil {
@@ -93,7 +125,7 @@ func bytesToAddress(input []byte) *Address {
 
 	// else try the old format
 	var temp struct {
-		RaftId   uint16
+		RaftId   uint64
 		NodeId   enode.EnodeID
 		Ip       net.IP
 		P2pPort  enr.TCP

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -15,6 +15,7 @@ import (
 // or `enode.Node`.
 // As NodeId is mainly used to derive the `ecdsa.pubkey` to build `enode.Node` it is kept as [64]byte instead of ID [32]byte used by `enode.Node`.
 type Address struct {
+	//RaftId   uint64        `json:"raftId"`
 	RaftId   uint64        `json:"raftId"`
 	NodeId   enode.EnodeID `json:"nodeId"`
 	Ip       net.IP        `json:"-"`

--- a/raft/peer.go
+++ b/raft/peer.go
@@ -16,7 +16,7 @@ import (
 // As NodeId is mainly used to derive the `ecdsa.pubkey` to build `enode.Node` it is kept as [64]byte instead of ID [32]byte used by `enode.Node`.
 type Address struct {
 	//RaftId   uint64        `json:"raftId"`
-	RaftId   uint64        `json:"raftId"`
+	RaftId   uint16        `json:"raftId"`
 	NodeId   enode.EnodeID `json:"nodeId"`
 	Ip       net.IP        `json:"-"`
 	P2pPort  enr.TCP       `json:"p2pPort"`
@@ -66,7 +66,7 @@ type ClusterInfo struct {
 	NodeActive bool   `json:"nodeActive"`
 }
 
-func newAddress(raftId uint64, raftPort int, node *enode.Node, useDns bool) *Address {
+func newAddress(raftId uint16, raftPort int, node *enode.Node, useDns bool) *Address {
 	// derive 64 byte nodeID from 128 byte enodeID
 	id, err := enode.RaftHexID(node.EnodeID())
 	if err != nil {
@@ -117,7 +117,6 @@ func (addr *Address) toBytes() []byte {
 }
 
 func bytesToAddress(input []byte) *Address {
-	log.Println(fmt.Sprintf("Libby [bytesToAddress] let's see the decoding " ))
 	// try the new format first
 	addr := new(Address)
 	streamNew := rlp.NewStream(bytes.NewReader(input), 0)
@@ -130,7 +129,7 @@ func bytesToAddress(input []byte) *Address {
 
 	// else try the old format
 	var temp struct {
-		RaftId   uint64
+		RaftId   uint16
 		NodeId   enode.EnodeID
 		Ip       net.IP
 		P2pPort  enr.TCP

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -30,7 +30,7 @@ type SnapshotWithHostnames struct {
 }
 
 type AddressWithoutHostname struct {
-	RaftId   uint64
+	RaftId   uint16
 	NodeId   enode.EnodeID
 	Ip       net.IP
 	P2pPort  enr.TCP
@@ -154,13 +154,13 @@ func (pm *ProtocolManager) updateClusterMembership(newConfState raftpb.ConfState
 	for _, tempAddress := range addresses {
 		address := tempAddress // Allocate separately on the heap for each iteration.
 
-		if address.RaftId == pm.raftId {
+		if uint64(address.RaftId) == pm.raftId {
 			// If we're a newcomer to an existing cluster, this is where we learn
 			// our own Address.
 			pm.setLocalAddress(&address)
 		} else {
 			pm.mu.RLock()
-			existingPeer := pm.peers[address.RaftId]
+			existingPeer := pm.peers[uint64(address.RaftId)]
 			pm.mu.RUnlock()
 
 			if existingPeer == nil {

--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -63,7 +63,7 @@ func (pm *ProtocolManager) buildSnapshot() *SnapshotWithHostnames {
 
 	// Populate addresses
 	for i, rawRaftId := range append(pm.confState.Nodes, pm.confState.Learners...) {
-		raftId := uint64(rawRaftId)
+		raftId := rawRaftId
 
 		if raftId == pm.raftId {
 			snapshot.Addresses[i] = *pm.address
@@ -117,7 +117,7 @@ func (pm *ProtocolManager) triggerSnapshot(index uint64) {
 func confStateIdSet(confState raftpb.ConfState) mapset.Set {
 	set := mapset.NewSet()
 	for _, rawRaftId := range append(confState.Nodes, confState.Learners...) {
-		set.Add(uint64(rawRaftId))
+		set.Add(rawRaftId)
 	}
 	return set
 }

--- a/raft/util.go
+++ b/raft/util.go
@@ -3,11 +3,12 @@ package raft
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"io"
 	"os"
 	"runtime"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // TODO: this is just copied over from cmd/utils/cmd.go. dedupe

--- a/raft/util.go
+++ b/raft/util.go
@@ -2,9 +2,11 @@ package raft
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/log"
 	"io"
 	"os"
 	"runtime"
+	"strconv"
 )
 
 // TODO: this is just copied over from cmd/utils/cmd.go. dedupe
@@ -27,4 +29,30 @@ func fatalf(format string, args ...interface{}) {
 	}
 	fmt.Fprintf(w, "Fatal: "+format+"\n", args...)
 	os.Exit(1)
+}
+
+// maps a node id (512 bit public key of the node) to a 64 bit raft id required by the etcd raft core.
+// note: enode ids in the network / static-nodes.json need to have unique 15 char prefixes.
+func nodeIdToRaftId(nodeId string) (uint64, error) {
+	log.Info("Converting node id to raft id", "node id", nodeId)
+	nodeIdChars := []rune(nodeId)
+	// a rune is an alias for int32
+	// raft id is an uint64, uint64 is the set of all signed 64-bit integers (-9223372036854775808 to 9223372036854775807)
+	// 0x7FFFFFFFFFFFFFFF == 9223372036854775807 (dec)
+	// len("7FFFFFFFFFFFFFFF")  == 16, so take the first 15 chars (16-1) of the node id to make sure it fits into an uint64
+	idShort := string(nodeIdChars[0:15])
+	log.Info("raft idshort ", "idShort", idShort)
+	raftId, err := strconv.ParseUint(idShort, 16, 64)
+	log.Info("raft id as uint64", "raftId uint64", raftId)
+	if err != nil {
+		log.Error("Error converting node id to uint64 raft id", "err", err)
+		return 0, err
+	}
+	return raftId, nil
+}
+
+// used to convert a uint64 to a string, needed for displaying the raftId properly in Javascript (raft/api.go), e.g.
+// raft.addPeer(enodeUrl) as JS Number and uint64 are not compatible.
+func RaftIdToString(raftId uint64) string {
+	return fmt.Sprintf("%d", raftId)
 }

--- a/raft/util.go
+++ b/raft/util.go
@@ -33,17 +33,19 @@ func fatalf(format string, args ...interface{}) {
 	os.Exit(1)
 }
 
-// maps an enode id (512 bit public key of the node) to a uint64 bit raft id required by the etcd raft core.
-// the enode ids for the network are obtianed from the static-nodes.json file.
+// maps an enode id (512 bit public key of the node) to a uint16 raft id.
+// TODO/note: (2020 Sept 20) the underlying ectd raft id is a uint64, but for quorum backwards compatibility / upgrade, we are keepting this
+//            a uint16, in the near future, we maybe want to provide an upgrade path for raft64
+// the enode ids for the network are obtained from the static-nodes.json file, or passed in when running raft.addPeer(enodeURL).
 // nodeIdToRaftId takes the Keccak hash of the enode id, which helps to avoid collisions and
 // ensure uniqueness, and converts the hash into an uint64 which is the raftId type used by the etcd
 // raft protocol.
-func nodeIdToRaftId(enodeId string) (uint64, error) {
+func nodeIdToRaftId(enodeId string) (uint16, error) {
 	log.Info("Converting node id to raft id", "enode id", enodeId)
 	// Get the keccak hash of of the enodeId to help ensure uniqueness and protect against collisions.
 	hashedEnodeId := crypto.Keccak256([]byte(enodeId))
 	log.Info("raft hashedEnodeId ", "hashedEnodeId", hashedEnodeId)
-	raftId := binary.BigEndian.Uint64(hashedEnodeId)
+	raftId := binary.BigEndian.Uint16(hashedEnodeId)
 	log.Info("raft raftId ", "raftId", raftId)
 	return raftId, nil
 }


### PR DESCRIPTION
The purpose of this PR is to address issue 1063  https://github.com/ConsenSys/quorum/issues/1063 "Raft: Modify to generate deterministic raftIds, remove required `--raftjoinexisting $raftId` flag "
to simplify adding / removing and managing nodes in a raft Quorum network. 

## Current Raft Flow Adding a Node (before this PR)

The current raft id is a monotonically increasing number that is calculated initially by the index of the nodes in the initial `static-nodes.json` file. The raft id being tied to the node's position in the `static-nodes.json` only holds when the network is being started for the first time, after that,  to add a new node to a quorum network the nodes must:
1. be added to a permisioned-nodes.json file on a cluster node.
2. an operator must run `raft.addPeer(enodeurl)` on a healthy node in the cluster and obtain the returned id (they cannot know this ahead of time).
3. the flag `--raftjoinexisting $RAFTID` must be included in the start up params of the node being added, and the id obtained from the operator must be set in the startup params.

The raftId for a node is not sticky, and if a raft node is removed from the cluster and re-added it must obtain a new raftId. Raft id are never reused to avoid race-conditions, and to compute a unique id when adding other nodes. This divergence of startup parameter makes make it difficult to mange a raft quorum network, e.g. from projects like [qubernetes](https://github.com/ConsenSys/qubernetes), and from other ops standpoints, as the node parameters as constantly changing, and values have to be obtained outside of the node before starting it up.

This PR makes the raftId deterministic, specifically it changes the raftid from a monotonically increasing `uint16` to a deterministic `uint64` Keccack hash of the enode id of each node. 
 
## Changes To Raft Id / Raft Flow

This PR changes the way that the raft id is calculated and greatly simplifies adding / removing and managing raft quorum nodes / network. 

* Each node can now calculate its own raft id as it the Keccack hash of its enode id.
* When a node is removed and re-added it will keep the same raft id.
* The order of the nodes (when initializing a quorum network) in the `static-nodes.json` is no longer important, as the order does not play a role in the calculating the raft id. 
* Removes the need for the  `--raftjoinexisting $raftid` startup parameter for nodes that are being added to the network.
* All nodes can have the same geth startup parameters, there is no difference between the params of an initial node and subsequent nodes being added to the network. 
* Collision are avoided due to the hash properties although it is not 256 but uint64, it should suffice for a reasonable sized raft network up to thousands of nodes. 
