### PR TITLE
Add API for account dump & transaction trace fix

### DIFF
--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -838,6 +838,11 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	signer := types.MakeSigner(api.eth.blockchain.Config(), block.Number())
 
 	for idx, tx := range block.Transactions() {
+		privateStateDbToUse := statedb
+		if api.eth.blockchain.Config().IsQuorum && tx.IsPrivate() {
+			privateStateDbToUse = privateStateDb
+		}
+
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer)
 		context := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
@@ -845,7 +850,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 			return msg, context, statedb, privateStateDb, nil
 		}
 		// Not yet the searched for transaction, execute on top of the current state
-		vmenv := vm.NewEVM(context, statedb, privateStateDb, api.eth.blockchain.Config(), vm.Config{})
+		vmenv := vm.NewEVM(context, statedb, privateStateDbToUse, api.eth.blockchain.Config(), vm.Config{})
 		if _, _, _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 			return nil, vm.Context{}, nil, nil, fmt.Errorf("tx %#x failed: %v", tx.Hash(), err)
 		}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -270,6 +270,12 @@ web3._extend({
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter, ""]
 		}),
 		new web3._extend.Method({
+			name: 'dumpAddress',
+			call: 'debug_dumpAddress',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'chaindbProperty',
 			call: 'debug_chaindbProperty',
 			params: 1,


### PR DESCRIPTION
A new API named `debug_dumpAddress` has been added in this PR, which fetches the state of an address at a given block height (including `pending` and `latest`). This includes it's code, balance, nonce, storage etc.
Note that the storage can get large, so the response can take some time. The request can also take some time due to needing to rebuild the contracts environment if the state isn't present, so if planning on using this API regularly  it is recommended to run the node in archive mode.

Also included is a bug fix for tracing transactions. If the transaction is public, a write operation would fail and abort the trace due to the private state being used instead of the public state. The public state is now set correctly in this case.