### PR TITLE
Expose the plugin@account API over clef's HTTP server

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -606,7 +606,7 @@ func signer(c *cli.Context) error {
 
 		// start http server
 		httpEndpoint := fmt.Sprintf("%s:%d", c.GlobalString(utils.RPCListenAddrFlag.Name), c.Int(rpcPortFlag.Name))
-		listener, _, _, err := rpc.StartHTTPEndpoint(httpEndpoint, rpcAPI, []string{"account"}, cors, vhosts, rpc.DefaultHTTPTimeouts, nil, nil)
+		listener, _, _, err := rpc.StartHTTPEndpoint(httpEndpoint, rpcAPI, []string{"account", "plugin@account"}, cors, vhosts, rpc.DefaultHTTPTimeouts, nil, nil)
 		if err != nil {
 			utils.Fatalf("Could not start RPC api: %v", err)
 		}


### PR DESCRIPTION
Prior to this change the plugin@account API was only available over IPC