### PR TITLE
ci/cd: publish Docker image to Docker Hub via GithubActions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,11 +49,28 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
         run: |
           make test all
+  publish-docker:
+    name: Publish Docker Image
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+      - name: 'Build and publish to Docker Hub'
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: ${{ secrets.DOCKER_REPO }}
+          tag_with_ref: true
+          add_git_labels: true
   notify:
     if: always()
     name: Notify
     needs:
       - build
+      - publish-docker
     runs-on: ubuntu-latest
     steps:
       - name: 'Setup metadata'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,20 @@ env:
   GOPATH: ${{ github.workspace }}/go
   WORKING_DIR: ${{ github.workspace }}/go/src/github.com/ethereum/go-ethereum
 jobs:
+  publish-docker:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+      - name: 'Build and publish to Docker Hub'
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: ${{ secrets.DOCKER_REPO }}
+          tag_with_ref: true
+          add_git_labels: true
   build:
     name: 'Build binary for ${{ matrix.os }}'
     strategy:
@@ -88,6 +102,7 @@ jobs:
     name: 'Draft Github release'
     needs:
       - deploy-bintray
+      - publish-docker
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out project files'
@@ -138,6 +153,7 @@ jobs:
     needs:
       - build
       - deploy-bintray
+      - publish-docker
       - draft-release
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <a href="https://www.goquorum.com/slack-inviter" target="_blank" rel="noopener"><img title="Quorum Slack" src="https://93ecjxb0d3.execute-api.us-east-1.amazonaws.com/Express/badge.svg" alt="Quorum Slack" /></a>
 ![Build Check](https://github.com/jpmorganchase/quorum/workflows/Build%20Check/badge.svg?branch=master)
-[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/quorumengineering/quorum)](https://hub.docker.com/r/quorumengineering/quorum/builds)
-[![Documentation Status](https://readthedocs.org/projects/goquorum/badge/?version=latest)](http://docs.goquorum.com/en/latest/?badge=latest)
 [![Download](https://api.bintray.com/packages/quorumengineering/quorum/geth/images/download.svg)](https://bintray.com/quorumengineering/quorum/geth/_latestVersion)
 [![Docker Pulls](https://img.shields.io/docker/pulls/quorumengineering/quorum)](https://hub.docker.com/r/quorumengineering/quorum)
 


### PR DESCRIPTION
Historically Docker image build was done using Docker Hub automated build infrastructure
The current repo move requires reconfiguring Docker Hub automated build.
It's simpler and more maintenable to use GithubActions to build and
publish Docker image to Docker Hub.