### PR TITLE
ci/cd: fix docker image tag mapping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,18 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
+      - name: 'Extract Docker Image Tag'
+        id: extract
+        run: |
+          REF=${{ github.ref }}
+          echo ::set-output name=image_tag::$(echo $REF | sed 's/refs\/tags\/v//g')
       - name: 'Build and publish to Docker Hub'
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ secrets.DOCKER_REPO }}
-          tag_with_ref: true
+          tags: ${{ steps.extract.outputs.image_tag }}
           add_git_labels: true
   build:
     name: 'Build binary for ${{ matrix.os }}'


### PR DESCRIPTION
This is to fix the Github Actions release workflow so with `vX.Y.Z` as Git tag, the corresponding docker image tag would be `X.Y.Z`