### PR TITLE
override the 5 secs default time out for eth_call

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -168,7 +168,7 @@ var (
 		utils.PluginLocalVerifyFlag,
 		utils.PluginPublicKeyFlag,
 		utils.AllowedFutureBlockTimeFlag,
-		utils.TimeOutForCall,
+		utils.EVMCallTimeOutFlag,
 		// End-Quorum
 	}
 

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -168,6 +168,7 @@ var (
 		utils.PluginLocalVerifyFlag,
 		utils.PluginPublicKeyFlag,
 		utils.AllowedFutureBlockTimeFlag,
+		utils.TimeOutForCall,
 		// End-Quorum
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -279,6 +279,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.PluginLocalVerifyFlag,
 			utils.PluginPublicKeyFlag,
 			utils.AllowedFutureBlockTimeFlag,
+			utils.TimeOutForCall,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -239,6 +239,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.VMEnableDebugFlag,
 			utils.EVMInterpreterFlag,
 			utils.EWASMInterpreterFlag,
+			// Quorum - timout for calls
+			utils.EVMCallTimeOutFlag,
 		},
 	},
 	{
@@ -279,7 +281,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.PluginLocalVerifyFlag,
 			utils.PluginPublicKeyFlag,
 			utils.AllowedFutureBlockTimeFlag,
-			utils.TimeOutForCall,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -823,6 +823,11 @@ var (
 		Name:  "raftdnsenable",
 		Usage: "Enable DNS resolution of peers",
 	}
+	TimeOutForCall = cli.IntFlag{
+		Name:  "timeoutforcall",
+		Usage: "timeout duration in seconds for eth_call execution. if passed as 0 there will be no time out",
+		Value: 5,
+	}
 
 	// Permission
 	EnableNodePermissionFlag = cli.BoolFlag{
@@ -1543,6 +1548,13 @@ func setRaft(ctx *cli.Context, cfg *eth.Config) {
 	cfg.RaftMode = ctx.GlobalBool(RaftModeFlag.Name)
 }
 
+func setQuorumConfig(ctx *cli.Context, cfg *eth.Config) {
+	cfg.TimeOutForCall = ctx.GlobalInt(TimeOutForCall.Name)
+
+	setIstanbul(ctx, cfg)
+	setRaft(ctx, cfg)
+}
+
 // CheckExclusive verifies that only a single instance of the provided flags was
 // set by the user. Each flag might optionally be followed by a string type to
 // specialize it further.
@@ -1617,8 +1629,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	setLes(ctx, cfg)
 
 	// Quorum
-	setIstanbul(ctx, cfg)
-	setRaft(ctx, cfg)
+	setQuorumConfig(ctx, cfg)
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -787,6 +787,13 @@ var (
 		Value: "",
 	}
 
+	// Quorum - added configurable call timeout for execution of calls
+	EVMCallTimeOutFlag = cli.IntFlag{
+		Name:  "vm.calltimeout",
+		Usage: "Timeout duration in seconds for message call execution without creating a transaction. Value 0 means no timeout.",
+		Value: 5,
+	}
+
 	// Quorum
 	// immutability threshold which can be passed as a parameter at geth start
 	QuorumImmutabilityThreshold = cli.IntFlag{
@@ -822,11 +829,6 @@ var (
 	RaftDNSEnabledFlag = cli.BoolFlag{
 		Name:  "raftdnsenable",
 		Usage: "Enable DNS resolution of peers",
-	}
-	TimeOutForCall = cli.IntFlag{
-		Name:  "timeoutforcall",
-		Usage: "timeout duration in seconds for eth_call execution. if passed as 0 there will be no time out",
-		Value: 5,
 	}
 
 	// Permission
@@ -1549,7 +1551,7 @@ func setRaft(ctx *cli.Context, cfg *eth.Config) {
 }
 
 func setQuorumConfig(ctx *cli.Context, cfg *eth.Config) {
-	cfg.TimeOutForCall = ctx.GlobalInt(TimeOutForCall.Name)
+	cfg.EVMCallTimeOut = time.Duration(ctx.GlobalInt(EVMCallTimeOutFlag.Name)) * time.Second
 
 	setIstanbul(ctx, cfg)
 	setRaft(ctx, cfg)

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -78,6 +78,15 @@ func TestSetImmutabilityThreshold(t *testing.T) {
 	assert.Equal(t, 100000, arbitraryCLIContext.GlobalInt(QuorumImmutabilityThreshold.Name), "immutability threshold value not set")
 }
 
+func TestSetTimeOutForCall(t *testing.T) {
+	fs := &flag.FlagSet{}
+	fs.Int(TimeOutForCall.Name, 0, "")
+	arbitraryCLIContext := cli.NewContext(nil, fs, nil)
+	assert.NoError(t, arbitraryCLIContext.GlobalSet(TimeOutForCall.Name, strconv.Itoa(10)))
+	assert.True(t, arbitraryCLIContext.GlobalIsSet(TimeOutForCall.Name), "timeoutforcall flag not set")
+	assert.Equal(t, 10, arbitraryCLIContext.GlobalInt(TimeOutForCall.Name), "timeoutforcall value not set")
+}
+
 func TestSetPlugins_whenTypical(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "q-")
 	if err != nil {

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -80,11 +80,11 @@ func TestSetImmutabilityThreshold(t *testing.T) {
 
 func TestSetTimeOutForCall(t *testing.T) {
 	fs := &flag.FlagSet{}
-	fs.Int(TimeOutForCall.Name, 0, "")
+	fs.Int(EVMCallTimeOutFlag.Name, 0, "")
 	arbitraryCLIContext := cli.NewContext(nil, fs, nil)
-	assert.NoError(t, arbitraryCLIContext.GlobalSet(TimeOutForCall.Name, strconv.Itoa(10)))
-	assert.True(t, arbitraryCLIContext.GlobalIsSet(TimeOutForCall.Name), "timeoutforcall flag not set")
-	assert.Equal(t, 10, arbitraryCLIContext.GlobalInt(TimeOutForCall.Name), "timeoutforcall value not set")
+	assert.NoError(t, arbitraryCLIContext.GlobalSet(EVMCallTimeOutFlag.Name, strconv.Itoa(10)))
+	assert.True(t, arbitraryCLIContext.GlobalIsSet(EVMCallTimeOutFlag.Name), "timeoutforcall flag not set")
+	assert.Equal(t, 10, arbitraryCLIContext.GlobalInt(EVMCallTimeOutFlag.Name), "timeoutforcall value not set")
 }
 
 func TestSetPlugins_whenTypical(t *testing.T) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -51,7 +52,7 @@ type EthAPIBackend struct {
 	hexNodeId string
 
 	// if set diables the time out for eth_call
-	timeOutForCall int
+	evmCallTimeOut time.Duration
 }
 
 // ChainConfig returns the active chain configuration.
@@ -335,8 +336,8 @@ func (b *EthAPIBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-func (b *EthAPIBackend) CallTimeOut() int {
-	return b.timeOutForCall
+func (b *EthAPIBackend) CallTimeOut() time.Duration {
+	return b.evmCallTimeOut
 }
 
 func (b *EthAPIBackend) RPCGasCap() *big.Int {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -51,7 +51,7 @@ type EthAPIBackend struct {
 	// hex node id from node public key
 	hexNodeId string
 
-	// if set diables the time out for eth_call
+	// timeout value for call
 	evmCallTimeOut time.Duration
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -49,6 +49,9 @@ type EthAPIBackend struct {
 	//
 	// hex node id from node public key
 	hexNodeId string
+
+	// if set diables the time out for eth_call
+	timeOutForCall int
 }
 
 // ChainConfig returns the active chain configuration.
@@ -330,6 +333,10 @@ func (b *EthAPIBackend) AccountManager() *accounts.Manager {
 
 func (b *EthAPIBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
+}
+
+func (b *EthAPIBackend) CallTimeOut() int {
+	return b.timeOutForCall
 }
 
 func (b *EthAPIBackend) RPCGasCap() *big.Int {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -244,7 +244,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData, eth.blockchain.Config().IsQuorum))
 
 	hexNodeId := fmt.Sprintf("%x", crypto.FromECDSAPub(&ctx.NodeKey().PublicKey)[1:]) // Quorum
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, hexNodeId, config.TimeOutForCall}
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, hexNodeId, config.EVMCallTimeOut}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -244,7 +244,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData, eth.blockchain.Config().IsQuorum))
 
 	hexNodeId := fmt.Sprintf("%x", crypto.FromECDSAPub(&ctx.NodeKey().PublicKey)[1:]) // Quorum
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, hexNodeId}
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, hexNodeId, config.TimeOutForCall}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/config.go
+++ b/eth/config.go
@@ -166,6 +166,6 @@ type Config struct {
 	// Istanbul block override (TODO: remove after the fork)
 	OverrideIstanbul *big.Int
 
-	// no time out fo eth_call
+	// timeout value for call
 	EVMCallTimeOut time.Duration
 }

--- a/eth/config.go
+++ b/eth/config.go
@@ -167,5 +167,5 @@ type Config struct {
 	OverrideIstanbul *big.Int
 
 	// no time out fo eth_call
-	TimeOutForCall int
+	EVMCallTimeOut time.Duration
 }

--- a/eth/config.go
+++ b/eth/config.go
@@ -165,4 +165,7 @@ type Config struct {
 
 	// Istanbul block override (TODO: remove after the fork)
 	OverrideIstanbul *big.Int
+
+	// no time out fo eth_call
+	TimeOutForCall int
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -20,7 +20,6 @@ package graphql
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -832,7 +831,9 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, vm.Config{}, 5*time.Second, b.backend.RPCGasCap())
+
+	// Quorum - replaced the default 5s time out with the value passed in vm.calltimeout
+	result, gas, failed, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, vm.Config{}, b.backend.CallTimeOut(), b.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0
@@ -898,7 +899,9 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.CallArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, vm.Config{}, 5*time.Second, p.backend.RPCGasCap())
+
+	// Quorum - replaced the default 5s time out with the value passed in vm.calltimeout
+	result, gas, failed, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, vm.Config{}, p.backend.CallTimeOut(), p.backend.RPCGasCap())
 	status := hexutil.Uint64(1)
 	if failed {
 		status = 0

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -981,11 +981,8 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 		accounts = *overrides
 	}
 
-	// Quorum
-	// read the timeout value from flag value of timeoutforcall
-	timeout := time.Duration(s.b.CallTimeOut()) * time.Second
-
-	result, _, _, err := DoCall(ctx, s.b, args, blockNrOrHash, accounts, vm.Config{}, timeout, s.b.RPCGasCap())
+	// Quorum - replaced the default 5s time out with the value passed in vm.calltimeout
+	result, _, _, err := DoCall(ctx, s.b, args, blockNrOrHash, accounts, vm.Config{}, s.b.CallTimeOut(), s.b.RPCGasCap())
 	return (hexutil.Bytes)(result), err
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -980,7 +980,12 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 	if overrides != nil {
 		accounts = *overrides
 	}
-	result, _, _, err := DoCall(ctx, s.b, args, blockNrOrHash, accounts, vm.Config{}, 5*time.Second, s.b.RPCGasCap())
+
+	// Quorum
+	// read the timeout value from flag value of timeoutforcall
+	timeout := time.Duration(s.b.CallTimeOut()) * time.Second
+
+	result, _, _, err := DoCall(ctx, s.b, args, blockNrOrHash, accounts, vm.Config{}, timeout, s.b.RPCGasCap())
 	return (hexutil.Bytes)(result), err
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -490,7 +491,7 @@ func (sb *StubBackend) ExtRPCEnabled() bool {
 	panic("implement me")
 }
 
-func (sb *StubBackend) CallTimeOut() int {
+func (sb *StubBackend) CallTimeOut() time.Duration {
 	panic("implement me")
 }
 

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -490,6 +490,10 @@ func (sb *StubBackend) ExtRPCEnabled() bool {
 	panic("implement me")
 }
 
+func (sb *StubBackend) CallTimeOut() int {
+	panic("implement me")
+}
+
 func (sb *StubBackend) RPCGasCap() *big.Int {
 	panic("implement me")
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -45,6 +45,7 @@ type Backend interface {
 	EventMux() *event.TypeMux
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
+	CallTimeOut() int
 	RPCGasCap() *big.Int // global gas cap for eth_call over rpc: DoS protection
 
 	// Blockchain API

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -20,6 +20,7 @@ package ethapi
 import (
 	"context"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -45,7 +46,7 @@ type Backend interface {
 	EventMux() *event.TypeMux
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
-	CallTimeOut() int
+	CallTimeOut() time.Duration
 	RPCGasCap() *big.Int // global gas cap for eth_call over rpc: DoS protection
 
 	// Blockchain API

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -258,8 +259,8 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
-func (b *LesApiBackend) CallTimeOut() int {
-	return 5
+func (b *LesApiBackend) CallTimeOut() time.Duration {
+	return 5 * time.Second
 }
 
 func (b *LesApiBackend) RPCGasCap() *big.Int {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -260,7 +260,7 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 }
 
 func (b *LesApiBackend) CallTimeOut() time.Duration {
-	return 5 * time.Second
+	return b.eth.config.EVMCallTimeOut
 }
 
 func (b *LesApiBackend) RPCGasCap() *big.Int {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -258,6 +258,10 @@ func (b *LesApiBackend) ExtRPCEnabled() bool {
 	return b.extRPCEnabled
 }
 
+func (b *LesApiBackend) CallTimeOut() int {
+	return 5
+}
+
 func (b *LesApiBackend) RPCGasCap() *big.Int {
 	return b.eth.config.RPCGasCap
 }


### PR DESCRIPTION
For `eth_call`, the default time out is set to 5 secs. If the call takes longer than 5 secs, the `evm` aborts and the call fails with error `execution aborted (timeout = 5s)`. 

There may be valid scenarios (e.g. for reporting) where the `eth_call` may take beyond the default 5s. Considering these scenarios a new flag `--vm.calltimeout` has been added to `geth` start up flags to pass the desired timeout duration for `eth_call`. The default value for this will be 5 seconds. If passed as 0 there will be no timeout.

fixes #1083 