### PR TITLE
ci/cd: Add YY.MM docker image tag on Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,14 @@ jobs:
         run: |
           REF=${{ github.ref }}
           echo ::set-output name=image_tag::$(echo $REF | sed 's/refs\/tags\/v//g')
+          echo ::set-output name=image_tag_minor_latest::$(echo $REF | sed -e 's/refs\/tags\/v//g' -e 's/\.[[:digit:]]$/-latest/g') 
       - name: 'Build and publish to Docker Hub'
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ secrets.DOCKER_REPO }}
-          tags: ${{ steps.extract.outputs.image_tag }}
+          tags: ${{ steps.extract.outputs.image_tag }}, ${{ steps.extract.outputs.image_tag_minor_latest }}
           add_git_labels: true
   build:
     name: 'Build binary for ${{ matrix.os }}'
@@ -125,7 +126,7 @@ jobs:
           echo "Last version: $last_version on $last_release_date"
           # pulling from git logs
           curl -q -s -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/search/issues?q=repo:jpmorganchase/quorum+is:pr+is:merged+merged%3A>=$last_release_date+sort%3Aupdated-desc" | jq -r '"* " + (.items[]|.title + " #" + (.number|tostring))' \
+            "https://api.github.com/search/issues?q=repo:ConsenSys/quorum+is:pr+is:merged+merged%3A>=$last_release_date+sort%3Aupdated-desc" | jq -r '"* " + (.items[]|.title + " #" + (.number|tostring))' \
             >> $file
           # pulling file hashes from Bintray
           echo "" >> $file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
         run: |
           REF=${{ github.ref }}
           echo ::set-output name=image_tag::$(echo $REF | sed 's/refs\/tags\/v//g')
-          echo ::set-output name=image_tag_minor_latest::$(echo $REF | sed -e 's/refs\/tags\/v//g' -e 's/\.[[:digit:]]$/-latest/g') 
+          echo ::set-output name=image_tag_minor_latest::$(echo $REF | sed -e 's/refs\/tags\/v//g' -e 's/^\([[:digit:]]*\.[[:digit:]]*\).*/\1/') 
       - name: 'Build and publish to Docker Hub'
         uses: docker/build-push-action@v1
-        with:
+        with: 
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ secrets.DOCKER_REPO }}


### PR DESCRIPTION
- Add YY.MM tag to docker images on Docker Hub
- Update the URL of Quorum repository from which PRs are scrapped to generate release-note