### PR TITLE
fix Github Actions workflows deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         # ###[error]    natupnp_test.go:165: not discovered
         # must be sommething with Github Actions VM networking setup.
         # Event Ubuntu requires a workaround
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-18.04"]
     env:
       QUORUM_IGNORE_TEST_PACKAGES: github.com/ethereum/go-ethereum/les,github.com/ethereum/go-ethereum/les/flowcontrol,github.com/ethereum/go-ethereum/mobile
     runs-on: ${{ matrix.os }}
@@ -44,7 +44,7 @@ jobs:
           sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
       - name: 'Prepare environment'
         run: |
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: 'Run tests and build all'
         working-directory: ${{ env.WORKING_DIR }}
         run: |
@@ -53,7 +53,7 @@ jobs:
     name: Publish Docker Image
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
     needs:
       - build
       - publish-docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Setup metadata'
         id: setup

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   lint:
     name: 'Code linters'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Setup Go ${{ env.GO_VERSION }}'
         uses: actions/setup-go@v1
@@ -22,7 +22,7 @@ jobs:
           submodules: false
       - name: 'Prepare environment'
         run: |
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: 'Run code linters'
         run: |
           GO111MODULE=off make lint
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-18.04"]
     env:
       QUORUM_IGNORE_TEST_PACKAGES: github.com/ethereum/go-ethereum/les,github.com/ethereum/go-ethereum/les/flowcontrol,github.com/ethereum/go-ethereum/mobile
     runs-on: ${{ matrix.os }}
@@ -49,13 +49,13 @@ jobs:
           # https://github.com/actions/virtual-environments/issues/798
           sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
 
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: 'Run unit tests'
         run: |
           make test
   docker-build:
     name: 'Build Docker image'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Check out project files'
         uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
         tag:
           - 'basic || basic-raft || (advanced && raft) || networks/typical::raft'
           - 'basic || basic-istanbul || (advanced && istanbul && !block-heights) || networks/typical::istanbul'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Download workflow artifact - Docker image'
         uses: actions/download-artifact@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   publish-docker:
     name: Publish Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-18.04", "macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 'Setup Go ${{ env.GO_VERSION }}'
@@ -43,7 +43,7 @@ jobs:
       - name: 'Prepare environment'
         id: env
         run: |
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
           echo "::set-output name=key::$(go env GOOS)_$(go env GOARCH)"
           echo "::set-output name=version::${GITHUB_REF##*/}"
       - name: 'Check out project files'
@@ -64,7 +64,7 @@ jobs:
           name: ${{ steps.env.outputs.key }}
   prepare-bintray:
     name: 'Prepare Bintray'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Setup jfrog CLI'
         uses: jfrog/setup-jfrog-cli@v1
@@ -89,7 +89,7 @@ jobs:
     needs:
       - build
       - prepare-bintray
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Setup jfrog CLI'
         uses: jfrog/setup-jfrog-cli@v1
@@ -109,7 +109,7 @@ jobs:
     needs:
       - deploy-bintray
       - publish-docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Check out project files'
         uses: actions/checkout@v2
@@ -161,7 +161,7 @@ jobs:
       - deploy-bintray
       - publish-docker
       - draft-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: 'Setup metadata'
         id: setup


### PR DESCRIPTION
- retire [add-path and set-env commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands) being used in Github Actions workflows
- use [ubuntu-18.04](https://github.com/actions/virtual-environments/issues/1816) consistently for builds