### PR TITLE
Replace etcd/raft module with modified 3.3.20 from Consensys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/ethereum/go-ethereum
 
 go 1.15
 
+// Quorum - Replace Go modules that use modifications done by us
 replace github.com/ethereum/go-ethereum/crypto/secp256k1 => github.com/jpmorganchase/quorum/crypto/secp256k1 v0.0.0-20200804194033-c8f07379f487
+replace github.com/coreos/etcd => github.com/ConsenSys/etcd v3.3.13-quorum+incompatible
+// End Quorum
 
 require (
 	github.com/Azure/azure-pipeline-go v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/ethereum/go-ethereum
 go 1.15
 
 // Quorum - Replace Go modules that use modifications done by us
+
 replace github.com/ethereum/go-ethereum/crypto/secp256k1 => github.com/jpmorganchase/quorum/crypto/secp256k1 v0.0.0-20200804194033-c8f07379f487
-replace github.com/coreos/etcd => github.com/ConsenSys/etcd v3.3.13-quorum+incompatible
+
+replace github.com/coreos/etcd => github.com/ConsenSys/etcd v3.3.20-quorum+incompatible
+
 // End Quorum
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VY
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/ConsenSys/etcd v3.3.13-quorum+incompatible h1:H94QQeecSEsBYj9PMIWv7LEDCco11uLrjRKt32SGDEc=
+github.com/ConsenSys/etcd v3.3.13-quorum+incompatible/go.mod h1:t5dz3KrzQ8YpaLZ/02LGkM9wlNiT3C4gaJ88wHx4yQY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.5 h1:zl/OfRA6nftbBK9qTohYBJ5xvw6C/oNKizR7cZGl3cI=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VY
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ConsenSys/etcd v3.3.13-quorum+incompatible h1:H94QQeecSEsBYj9PMIWv7LEDCco11uLrjRKt32SGDEc=
-github.com/ConsenSys/etcd v3.3.13-quorum+incompatible/go.mod h1:t5dz3KrzQ8YpaLZ/02LGkM9wlNiT3C4gaJ88wHx4yQY=
+github.com/ConsenSys/etcd v3.3.20-quorum+incompatible h1:FE06TVj1VJ5dPB/sE9KG8tZ+GL97vHdDtKIc4mYkF/M=
+github.com/ConsenSys/etcd v3.3.20-quorum+incompatible/go.mod h1:t5dz3KrzQ8YpaLZ/02LGkM9wlNiT3C4gaJ88wHx4yQY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.5 h1:zl/OfRA6nftbBK9qTohYBJ5xvw6C/oNKizR7cZGl3cI=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
@@ -56,8 +56,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9 h1:J82+/8rub3qSy0HxEnoYD8cs+HDlHWYrqYXe2Vqxluk=
 github.com/cloudflare/cloudflare-go v0.10.2-0.20190916151808-a80f83b9add9/go.mod h1:1MxXX1Ux4x6mqPmjkUgTP1CdXIBXKX7T+Jk9Gxrmx+U=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coreos/etcd v3.3.20+incompatible h1:jIrdkuJDHmyh6VZsxQQ3LQGfOrwgJx6sILz/lxzXsGw=
-github.com/coreos/etcd v3.3.20+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=


### PR DESCRIPTION
## Summary

Apply upstream fix on raft 3.4 to the current version we use (3.3.20), to make the learner node sync up with the leader.

## Changes

* Use a modified version of v3.3.20 in the repo https://github.com/ConsenSys/etcd/tree/v3.3.20-quorum