### PR TITLE
eth: fix issue peer <=eth64 unsupported  message.

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -729,7 +729,9 @@ func (ps *peerSet) Register(p *peer) error {
 
 	go p.broadcastBlocks()
 	go p.broadcastTransactions()
-	go p.announceTransactions()
+	if p.version >= eth65 {
+		go p.announceTransactions()
+	}
 
 	return nil
 }


### PR DESCRIPTION
eth64, eth63 do not support NewPooledTransactionHashesMsg, as it was
added in eth65. If a peer running eth version <=eth65 receives
NewPooledTransactionHashesMsg the peer will disconnect as it is
an unsupported message. NewPooledTransactionHashesMsg is used
in p.announceTransactions(). Only run announceTransaction() if
the peer we are registering is running version  >=eth65.