### PR TITLE
[Lint] Increase timeout fix issues with PR pipelines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file configures github.com/golangci/golangci-lint.
 
 run:
-  timeout: 2m
+  timeout: 5m
   tests: true
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$


### PR DESCRIPTION
### Summary

Currently, there are many failures with timeouts in the linter so this should fix the problem.

### Changes

* Increase timeout to 5minutes