### PR TITLE
Support eth and consensus subprotocols 

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -155,7 +155,7 @@ func (sb *backend) Gossip(valSet istanbul.ValidatorSet, payload []byte) error {
 
 			m.Add(hash, true)
 			sb.recentMessages.Add(addr, m)
-			go p.Send(istanbulMsg, payload)
+			go p.SendConsensus(istanbulMsg, payload)
 		}
 	}
 	return nil

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -91,6 +91,8 @@ func (sb *backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 		})
 		return true, nil
 	}
+	//https://github.com/ConsenSys/quorum/pull/539
+	//https://github.com/ConsenSys/quorum/issues/389
 	if msg.Code == NewBlockMsg && sb.core.IsProposer() { // eth.NewBlockMsg: import cycle
 		// this case is to safeguard the race of similar block which gets propagated from other node while this node is proposing
 		// as p2p.Msg can only be decoded once (get EOF for any subsequence read), we need to make sure the payload is restored after we decode it

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -16,13 +16,17 @@ const (
 	eth65      = 65
 	Istanbul64 = 64
 	Istanbul99 = 99
+	// this istanbul subprotocol will be registered in addition to "eth"
+	Istanbul100 = 100
 )
 
 var (
 	IstanbulProtocol = Protocol{
 		Name:     "istanbul",
-		Versions: []uint{Istanbul99, Istanbul64},
-		Lengths:  map[uint]uint64{Istanbul99: 18, Istanbul64: 18},
+		Versions: []uint{Istanbul100, Istanbul99, Istanbul64},
+		// istanbul/100 has to have 18 message to be backwards compatible although at the p2p layer it only has
+		// 1 message with msg.Code 17
+		Lengths: map[uint]uint64{Istanbul100: 18, Istanbul99: 18, Istanbul64: 18},
 	}
 
 	CliqueProtocol = Protocol{
@@ -67,4 +71,7 @@ type Broadcaster interface {
 type Peer interface {
 	// Send sends the message to this peer
 	Send(msgcode uint64, data interface{}) error
+
+	// SendConsensus sends the message to this p2p peer using the consensus specific devp2p subprotocol
+	SendConsensus(msgcode uint64, data interface{}) error
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -211,7 +211,9 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		dbVer = fmt.Sprintf("%d", *bcVersion)
 	}
 	log.Info("Initialising Ethereum protocol", "name", protocolName, "versions", ProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
-	log.Info("Initialising Quorum consensus protocol", "name", quorumConsensusProtocolName, "versions", quorumConsensusProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
+	if chainConfig.IsQuorum {
+		log.Info("Initialising Quorum consensus protocol", "name", quorumConsensusProtocolName, "versions", quorumConsensusProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
+	}
 
 	if !config.SkipBcVersionCheck {
 		if bcVersion != nil && *bcVersion > core.BlockChainVersion {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -186,10 +186,19 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	}
 
 	// Quorum: Set protocol Name/Version
+	// keep `var protocolName = "eth"` as is, and only update the quorum consensus specific protocol
+	// This is used to enable the eth service to return multiple devp2p subprotocols.
+	// Previously, for istanbul/64 istnbul/99 and clique (v2.6) `protocolName` would be overridden and
+	// set to the consensus subprotocol name instead of "eth", meaning the node would no longer
+	// communicate over the "eth" subprotocol, e.g. "eth" or "istanbul/99" but not eth" and "istanbul/99".
+	// With this change, support is added so that the "eth" subprotocol remains and optionally a consensus subprotocol
+	// can be added allowing the node to communicate over "eth" and an optional consensus subprotocol, e.g. "eth" and "istanbul/100"
 	if chainConfig.IsQuorum {
 		quorumProtocol := eth.engine.Protocol()
-		protocolName = quorumProtocol.Name
-		ProtocolVersions = quorumProtocol.Versions
+		// set the quorum specific consensus devp2p subprotocol, eth subprotocol remains set to protocolName as in upstream geth.
+		quorumConsensusProtocolName = quorumProtocol.Name
+		quorumConsensusProtocolVersions = quorumProtocol.Versions
+		quorumConsensusProtocolLengths = quorumProtocol.Lengths
 	}
 
 	// force to set the istanbul etherbase to node key address
@@ -202,6 +211,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		dbVer = fmt.Sprintf("%d", *bcVersion)
 	}
 	log.Info("Initialising Ethereum protocol", "name", protocolName, "versions", ProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
+	log.Info("Initialising Quorum consensus protocol", "name", quorumConsensusProtocolName, "versions", quorumConsensusProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
 
 	if !config.SkipBcVersionCheck {
 		if bcVersion != nil && *bcVersion > core.BlockChainVersion {
@@ -567,6 +577,17 @@ func (s *Ethereum) Downloader() *downloader.Downloader { return s.protocolManage
 func (s *Ethereum) Synced() bool                       { return atomic.LoadUint32(&s.protocolManager.acceptTxs) == 1 }
 func (s *Ethereum) ArchiveMode() bool                  { return s.config.NoPruning }
 
+// Quorum
+// adds quorum specific protocols to the Protocols() function which in the associated upstream geth version returns
+// only one subprotocol, "eth", and the supported versions of the "eth" protocol.
+// Quorum uses the eth service to run configurable consensus protocols, e.g. istanbul. Thru release v20.10.0
+// the "eth" subprotocol would be replaced with a modified subprotocol, e.g. "istanbul/99" which would contain all the "eth"
+// messages + the istanbul message and be communicated over the consensus specific subprotocol ("istanbul"), and
+// not over "eth".
+// Now the eth service supports multiple protocols, e.g. "eth" and an optional consensus
+// protocol, e.g. "istanbul/100".
+// /Quorum
+
 // Protocols implements node.Service, returning all the currently configured
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
@@ -579,6 +600,15 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 	if s.lesServer != nil {
 		protos = append(protos, s.lesServer.Protocols()...)
 	}
+
+	// /Quorum
+	// add additional quorum consensus protocol if set and if not set to "eth", e.g. istanbul
+	if quorumConsensusProtocolName != "" && quorumConsensusProtocolName != protocolName {
+		quorumProtos := s.quorumConsensusProtocols()
+		protos = append(protos, quorumProtos...)
+	}
+	// /end Quorum
+
 	return protos
 }
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -394,11 +394,7 @@ func (pm *ProtocolManager) handle(p *peer, protoName string) error {
 	}
 
 	// Quorum notify other subprotocols that the eth peer is ready, and has been added to the peerset.
-	select {
-	case p.EthPeerRegistered <- true:
-	default:
-		p.Log().Debug("no subprotocol waiting on EthPeerRegistered", "protoName", protoName)
-	}
+	p.EthPeerRegistered <- struct{}{}
 	// Quorum
 
 	// Handle incoming messages until the connection is torn down

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -220,13 +220,13 @@ func NewProtocolManager(config *params.ChainConfig, checkpoint *params.TrustedCh
 
 func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 	// Quorum: Set p2p.Protocol info from engine.Protocol()
-	length, ok := pm.engine.Protocol().Lengths[version]
+	length, ok := protocolLengths[version]
 	if !ok {
 		panic("makeProtocol for unknown version")
 	}
 
 	return p2p.Protocol{
-		Name:    pm.engine.Protocol().Name,
+		Name:    protocolName,
 		Version: version,
 		Length:  length,
 		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
@@ -235,7 +235,7 @@ func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 			case pm.newPeerCh <- peer:
 				pm.wg.Add(1)
 				defer pm.wg.Done()
-				return pm.handle(peer)
+				return pm.handle(peer, protocolName)
 			case <-pm.quitSync:
 				return p2p.DiscQuitting
 			}
@@ -330,9 +330,10 @@ func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter, ge
 	return newPeer(pv, p, rw, getPooledTx)
 }
 
+// quorum: protoname is either "eth" or a subprotocol that overrides "eth", e.g. legacy "istanbul/99"
 // handle is the callback invoked to manage the life cycle of an eth peer. When
 // this function terminates, the peer is disconnected.
-func (pm *ProtocolManager) handle(p *peer) error {
+func (pm *ProtocolManager) handle(p *peer, protoName string) error {
 	// Ignore maxPeers if this is a trusted peer
 	if pm.peers.Len() >= pm.maxPeers && !p.Peer.Info().Network.Trusted {
 		return p2p.DiscTooManyPeers
@@ -347,8 +348,8 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		number  = head.Number.Uint64()
 		td      = pm.blockchain.GetTd(hash, number)
 	)
-	if err := p.Handshake(pm.networkID, td, hash, genesis.Hash(), forkid.NewID(pm.blockchain), pm.forkFilter, pm.engine.Protocol().Name); err != nil {
-		p.Log().Debug("Ethereum handshake failed", "err", err)
+	if err := p.Handshake(pm.networkID, td, hash, genesis.Hash(), forkid.NewID(pm.blockchain), pm.forkFilter, protoName); err != nil {
+		p.Log().Debug("Ethereum handshake failed", "protoName", protoName, "err", err)
 		return err
 	}
 	// Register the peer locally
@@ -391,6 +392,15 @@ func (pm *ProtocolManager) handle(p *peer) error {
 			return err
 		}
 	}
+
+	// Quorum notify other subprotocols that the eth peer is ready, and has been added to the peerset.
+	select {
+	case p.EthPeerRegistered <- true:
+	default:
+		p.Log().Debug("no subprotocol waiting on EthPeerRegistered", "protoName", protoName)
+	}
+	// Quorum
+
 	// Handle incoming messages until the connection is torn down
 	for {
 		if err := pm.handleMsg(p); err != nil {
@@ -425,7 +435,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			log.Info("raft: ignoring message", "code", msg.Code)
 			return nil
 		}
-	} else if handler, ok := pm.engine.(consensus.Handler); ok {
+	} else if handler, ok := pm.engine.(consensus.Handler); ok { // quorum: NewBlock required for consensus, e.g. "istanbul"
 		pubKey := p.Node().Pubkey()
 		addr := crypto.PubkeyToAddress(*pubKey)
 		handled, err := handler.HandleMsg(addr, msg)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -353,7 +353,7 @@ func (pm *ProtocolManager) handle(p *peer, protoName string) error {
 		return err
 	}
 	// Register the peer locally
-	if err := pm.peers.Register(p); err != nil {
+	if err := pm.peers.Register(p, protoName); err != nil {
 		p.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -238,7 +238,7 @@ func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*te
 	go func() {
 		select {
 		case pm.newPeerCh <- peer:
-			errc <- pm.handle(peer)
+			errc <- pm.handle(peer, protocolName)
 		case <-pm.quitSync:
 			errc <- p2p.DiscQuitting
 		}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -108,6 +108,8 @@ type peer struct {
 	getPooledTx func(common.Hash) *types.Transaction // Callback used to retrieve transaction from txpool
 
 	term chan struct{} // Termination channel to stop the broadcaster
+
+	consensusRw p2p.MsgReadWriter // Quorum: this is the RW for the consensus devp2p protocol, e.g. "istanbul/100"
 }
 
 func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter, getPooledTx func(hash common.Hash) *types.Transaction) *peer {
@@ -330,6 +332,7 @@ func (p *peer) MarkTransaction(hash common.Hash) {
 	p.knownTxs.Add(hash)
 }
 
+// Quorum: this was added with the origin "istanbul" implementation.
 // Send writes an RLP-encoded message with the given code.
 // data should encode as an RLP list.
 func (p *peer) Send(msgcode uint64, data interface{}) error {

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -715,10 +715,14 @@ func newPeerSet() *peerSet {
 	}
 }
 
+// Quorum protoName is needed to check if the peer is running eth protocol or a legacy quorum
+// consensus protocol, e.g. istanbul/99 which would not support p.announceTransactions() / NewPooledTransactionHashesMsg
+// Quorum
+
 // Register injects a new peer into the working set, or returns an error if the
 // peer is already known. If a new peer it registered, its broadcast loop is also
 // started.
-func (ps *peerSet) Register(p *peer) error {
+func (ps *peerSet) Register(p *peer, protoName string) error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
@@ -732,7 +736,9 @@ func (ps *peerSet) Register(p *peer) error {
 
 	go p.broadcastBlocks()
 	go p.broadcastTransactions()
-	if p.version >= eth65 {
+	// Quorum passes in and checks the protoName to see if it is "eth"
+	// as it could also be a legacy protocol, e.g. "istanbul/99", protocolName is always set to "eth" for the eth service.
+	if p.version >= eth65 && protoName == protocolName {
 		go p.announceTransactions()
 	}
 

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -43,7 +43,7 @@ var protocolName = "eth"
 var ProtocolVersions = []uint{eth65, eth64, eth63}
 
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
-// var protocolLengths = map[uint]uint64{eth65: 17, eth64: 17, eth63: 17}
+var protocolLengths = map[uint]uint64{eth65: 17, eth64: 17, eth63: 17}
 
 const protocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
 

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -193,8 +193,8 @@ func TestForkIDSplit(t *testing.T) {
 	peerProFork := newPeer(64, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
 	errc := make(chan error, 2)
-	go func() { errc <- ethNoFork.handle(peerProFork) }()
-	go func() { errc <- ethProFork.handle(peerNoFork) }()
+	go func() { errc <- ethNoFork.handle(peerProFork, protocolName) }()
+	go func() { errc <- ethProFork.handle(peerNoFork, protocolName) }()
 
 	select {
 	case err := <-errc:
@@ -212,8 +212,8 @@ func TestForkIDSplit(t *testing.T) {
 	peerProFork = newPeer(64, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
 	errc = make(chan error, 2)
-	go func() { errc <- ethNoFork.handle(peerProFork) }()
-	go func() { errc <- ethProFork.handle(peerNoFork) }()
+	go func() { errc <- ethNoFork.handle(peerProFork, protocolName) }()
+	go func() { errc <- ethProFork.handle(peerNoFork, protocolName) }()
 
 	select {
 	case err := <-errc:
@@ -231,8 +231,8 @@ func TestForkIDSplit(t *testing.T) {
 	peerProFork = newPeer(64, p2p.NewPeer(enode.ID{2}, "", nil), p2pProFork, nil)
 
 	errc = make(chan error, 2)
-	go func() { errc <- ethNoFork.handle(peerProFork) }()
-	go func() { errc <- ethProFork.handle(peerNoFork) }()
+	go func() { errc <- ethNoFork.handle(peerProFork, protocolName) }()
+	go func() { errc <- ethProFork.handle(peerNoFork, protocolName) }()
 
 	select {
 	case err := <-errc:
@@ -381,8 +381,8 @@ func testSyncTransaction(t *testing.T, propagtion bool) {
 	// Sync up the two peers
 	io1, io2 := p2p.MsgPipe()
 
-	go pmSender.handle(pmSender.newPeer(65, p2p.NewPeer(enode.ID{}, "sender", nil), io2, pmSender.txpool.Get))
-	go pmFetcher.handle(pmFetcher.newPeer(65, p2p.NewPeer(enode.ID{}, "fetcher", nil), io1, pmFetcher.txpool.Get))
+	go pmSender.handle(pmSender.newPeer(65, p2p.NewPeer(enode.ID{}, "sender", nil), io2, pmSender.txpool.Get), protocolName)
+	go pmFetcher.handle(pmFetcher.newPeer(65, p2p.NewPeer(enode.ID{}, "fetcher", nil), io1, pmFetcher.txpool.Get), protocolName)
 
 	time.Sleep(250 * time.Millisecond)
 	pmFetcher.synchronise(pmFetcher.peers.BestPeer())

--- a/eth/quorum_protocol.go
+++ b/eth/quorum_protocol.go
@@ -1,0 +1,211 @@
+package eth
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// Quorum: quorum_protocol enables the eth service to return two different protocols, one for the eth mainnet "eth" service,
+//         and one for the quorum specific consensus algo, obtained from engine.consensus
+//         2021 Jan in the future consensus (istanbul) may run from its own service and use a single subprotocol there,
+//         instead of overloading the eth service.
+
+var (
+	// errEthPeerNil is returned when no eth peer is found to be associated with a p2p peer.
+	errEthPeerNil = errors.New("eth peer was nil")
+)
+
+// quorum consensus Protocol variables are optionally set in addition to the "eth" protocol variables (eth/protocol.go).
+var quorumConsensusProtocolName = ""
+
+// ProtocolVersions are the supported versions of the quorum consensus protocol (first is primary), e.g. []uint{Istanbul64, Istanbul99, Istanbul100}.
+var quorumConsensusProtocolVersions []uint
+
+// protocol Length describe the number of messages support by the protocol/version map[uint]uint64{Istanbul64: 18, Istanbul99: 18, Istanbul100: 18}
+var quorumConsensusProtocolLengths map[uint]uint64
+
+// makeQuorumConsensusProtocol is similar to eth/handler.go -> makeProtocol. Called from eth/handler.go -> Protocols.
+// returns the supported subprotocol to the p2p server.
+// The Run method starts the protocol and is called by the p2p server. The quorum consensus subprotocol,
+// leverages the peer created and managed by the "eth" subprotocol.
+// The quorum consensus protocol requires that the "eth" protocol is running as well.
+func (pm *ProtocolManager) makeQuorumConsensusProtocol(ProtoName string, version uint, length uint64) p2p.Protocol {
+
+	return p2p.Protocol{
+		Name:    ProtoName,
+		Version: version,
+		Length:  length,
+		// no new peer created, uses the "eth" peer, so no peer management needed.
+		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+			/*
+			* 1. wait for the eth protocol to create and register an eth peer.
+			* 2. get the associate eth peer that was registered by he "eth" protocol.
+			* 2. add the rw protocol for the quorum subprotocol to the eth peer.
+			* 3. start listening for incoming messages.
+			* 4. the incoming message will be sent on the quorum specific subprotocol, e.g. "istanbul/100".
+			* 5. send messages to the consensus engine handler.
+			* 7. messages to other to other peers listening to the subprotocol can be sent using the
+			*    (eth)peer.ConsensusSend() which will write to the protoRW.
+			 */
+			p2pPeerId := fmt.Sprintf("%x", p.ID().Bytes()[:8])
+			// wait for the "eth" protocol to create and register the peer
+			<-p.EthPeerRegistered
+			// the ethpeer should be registered, try to retrieve it and start the consensus handler.
+			ethPeer := pm.peers.Peer(p2pPeerId)
+			if ethPeer != nil {
+				p.Log().Debug("consensus subprotocol retrieved eth peer from peerset", "ethPeer.id", ethPeer.id, "ProtoName", ProtoName)
+				// add the rw protocol for the quorum subprotocol to the eth peer.
+				ethPeer.addConsensusProtoRW(rw)
+				return pm.handleConsensusLoop(p, rw)
+			}
+			p.Log().Error("consensus subprotocol retrieved nil eth peer from peerset", "ethPeer.id", ethPeer)
+			return errEthPeerNil
+		},
+		NodeInfo: func() interface{} {
+			return pm.NodeInfo()
+		},
+		PeerInfo: func(id enode.ID) interface{} {
+			if p := pm.peers.Peer(fmt.Sprintf("%x", id[:8])); p != nil {
+				return p.Info()
+			}
+			return nil
+		},
+	}
+}
+
+func (pm *ProtocolManager) handleConsensusLoop(p *p2p.Peer, protoRW p2p.MsgReadWriter) error {
+	// Handle incoming messages until the connection is torn down
+	for {
+		if err := pm.handleConsensus(p, protoRW); err != nil {
+			p.Log().Debug("Ethereum quorum message handling failed", "err", err)
+			return err
+		}
+	}
+}
+
+// This is a no-op because the eth handleMsg main loop handle ibf message as well.
+func (pm *ProtocolManager) handleConsensus(p *p2p.Peer, protoRW p2p.MsgReadWriter) error {
+	// Read the next message from the remote peer (in protoRW), and ensure it's fully consumed
+	msg, err := protoRW.ReadMsg()
+	if err != nil {
+		return err
+	}
+	if msg.Size > protocolMaxMsgSize {
+		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, protocolMaxMsgSize)
+	}
+	defer msg.Discard()
+
+	// See if the consensus engine protocol can handle this message, e.g. istanbul will check for message is
+	// istanbulMsg = 0x11, and NewBlockMsg = 0x07.
+	handled, err := pm.handleConsensusMsg(p, msg)
+	if handled {
+		p.Log().Debug("consensus message was handled by consensus engine", "handled", handled,
+			"quorumConsensusProtocolName", quorumConsensusProtocolName, "err", err)
+		return err
+	}
+
+	return nil
+}
+
+func (pm *ProtocolManager) handleConsensusMsg(p *p2p.Peer, msg p2p.Msg) (bool, error) {
+	if handler, ok := pm.engine.(consensus.Handler); ok {
+		pubKey := p.Node().Pubkey()
+		addr := crypto.PubkeyToAddress(*pubKey)
+		handled, err := handler.HandleMsg(addr, msg)
+		return handled, err
+	}
+	return false, nil
+}
+
+// makeLegacyProtocol is basically a copy of the eth makeProtocol, but for legacy subprtocols, e.g. "istanbul/99" "istabnul/64"
+// If support legacy subprotocols is removed, remove this and associated code as well.
+// If quorum is using a legacy protocol then the "eth" subprotocol should not be available.
+func (pm *ProtocolManager) makeLegacyProtocol(protoName string, version uint, length uint64) p2p.Protocol {
+	log.Debug("registering a legacy protocol ", "protoName", protoName)
+	return p2p.Protocol{
+		Name:    protoName,
+		Version: version,
+		Length:  length,
+		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+			peer := pm.newPeer(int(version), p, rw, pm.txpool.Get)
+			peer.addConsensusProtoRW(rw)
+			select {
+			case pm.newPeerCh <- peer:
+				pm.wg.Add(1)
+				defer pm.wg.Done()
+				// only need the protocol name for the handshake, so pass it in instead of global variable.
+				return pm.handle(peer, protoName)
+			case <-pm.quitSync:
+				return p2p.DiscQuitting
+			}
+		},
+		NodeInfo: func() interface{} {
+			return pm.NodeInfo()
+		},
+		PeerInfo: func(id enode.ID) interface{} {
+			if p := pm.peers.Peer(fmt.Sprintf("%x", id[:8])); p != nil {
+				return p.Info()
+			}
+			return nil
+		},
+	}
+}
+
+func (s *Ethereum) quorumConsensusProtocols() []p2p.Protocol {
+	protos := make([]p2p.Protocol, len(quorumConsensusProtocolVersions))
+	for i, vsn := range quorumConsensusProtocolVersions {
+		// if we have a legacy protocol, e.g. istanbul/99, istanbul/64 then the protocol handler is will be the "eth"
+		// protocol handler, and the subprotocol "eth" will not be used, but rather the legacy subprotocol will handle
+		// both eth messages and consensus messages.
+		if isLegacyProtocol(quorumConsensusProtocolName, vsn) {
+			length, ok := quorumConsensusProtocolLengths[vsn]
+			if !ok {
+				panic("makeProtocol for unknown version")
+			}
+			lp := s.protocolManager.makeLegacyProtocol(quorumConsensusProtocolName, vsn, length)
+			protos[i] = lp
+		} else {
+			length, ok := quorumConsensusProtocolLengths[vsn]
+			if !ok {
+				panic("makeQuorumConsensusProtocol for unknown version")
+			}
+			protos[i] = s.protocolManager.makeQuorumConsensusProtocol(quorumConsensusProtocolName, vsn, length)
+		}
+	}
+	return protos
+}
+
+// istanbul/64, istanbul/99, clique/63, clique/64 all override the "eth" subprotocol.
+func isLegacyProtocol(name string, version uint) bool {
+	legacyProtocols := map[string][]uint{"istanbul": {64, 99}, "clique": {63, 64}}
+	for lpName, lpVersions := range legacyProtocols {
+		if lpName == name {
+			for _, v := range lpVersions {
+				if v == version {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// Used to send consensus subprotocol messages from an "eth" peer, e.g.  "istanbul/100" subprotocol messages.
+func (p *peer) SendConsensus(msgcode uint64, data interface{}) error {
+	if p.consensusRw == nil {
+		return nil
+	}
+	return p2p.Send(p.consensusRw, msgcode, data)
+}
+
+func (p *peer) addConsensusProtoRW(rw p2p.MsgReadWriter) *peer {
+	p.consensusRw = rw
+	return p
+}

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -46,8 +46,8 @@ func testFastSyncDisabling(t *testing.T, protocol int) {
 	// Sync up the two peers
 	io1, io2 := p2p.MsgPipe()
 
-	go pmFull.handle(pmFull.newPeer(protocol, p2p.NewPeer(enode.ID{}, "empty", nil), io2, pmFull.txpool.Get))
-	go pmEmpty.handle(pmEmpty.newPeer(protocol, p2p.NewPeer(enode.ID{}, "full", nil), io1, pmEmpty.txpool.Get))
+	go pmFull.handle(pmFull.newPeer(protocol, p2p.NewPeer(enode.ID{}, "empty", nil), io2, pmFull.txpool.Get), protocolName)
+	go pmEmpty.handle(pmEmpty.newPeer(protocol, p2p.NewPeer(enode.ID{}, "full", nil), io1, pmEmpty.txpool.Get), protocolName)
 
 	time.Sleep(250 * time.Millisecond)
 	pmEmpty.synchronise(pmEmpty.peers.BestPeer())

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -116,6 +116,9 @@ type Peer struct {
 
 	// events receives message send / receive events if set
 	events *event.Feed
+
+	// Quorum
+	EthPeerRegistered chan bool
 }
 
 // NewPeer returns a peer for testing purposes.
@@ -189,6 +192,8 @@ func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
 		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
 		closed:   make(chan struct{}),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
+		// Quorum
+		EthPeerRegistered: make(chan bool),
 	}
 	return p
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -169,6 +169,14 @@ func (p *Peer) Disconnect(reason DiscReason) {
 	case p.disc <- reason:
 	case <-p.closed:
 	}
+
+	// Quorum
+	// if a quorum eth service subprotocol is waiting on EthPeerRegistered, notify the peer that it was not registered.
+	select {
+	case p.EthPeerRegistered <- false:
+	default:
+	}
+	// Quorum
 }
 
 // String implements fmt.Stringer.

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -118,7 +118,8 @@ type Peer struct {
 	events *event.Feed
 
 	// Quorum
-	EthPeerRegistered chan bool
+	EthPeerRegistered   chan struct{}
+	EthPeerDisconnected chan struct{}
 }
 
 // NewPeer returns a peer for testing purposes.
@@ -173,7 +174,7 @@ func (p *Peer) Disconnect(reason DiscReason) {
 	// Quorum
 	// if a quorum eth service subprotocol is waiting on EthPeerRegistered, notify the peer that it was not registered.
 	select {
-	case p.EthPeerRegistered <- false:
+	case p.EthPeerDisconnected <- struct{}{}:
 	default:
 	}
 	// Quorum
@@ -201,7 +202,8 @@ func newPeer(log log.Logger, conn *conn, protocols []Protocol) *Peer {
 		closed:   make(chan struct{}),
 		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
 		// Quorum
-		EthPeerRegistered: make(chan bool),
+		EthPeerRegistered:   make(chan struct{}, 1),
+		EthPeerDisconnected: make(chan struct{}, 1),
 	}
 	return p
 }


### PR DESCRIPTION
Enable the eth service to support multiple subprtocols, e.g.
"eth" AND "istanbul/100", instead of a single protocol, e.g. "eth" OR "istanbul/99".

When istanbul consensus was originally added, the eth service was
modified to override the eth subprotocol maintained by the eth service
to an quorum specific consensus protocol, e.g. "istanbul/99" meaning all
eth p2p messages would be sent over a consensus specific protocol in
addition to any consensus protocol message. In the case of istanbul,
the "eth" subprotocol would no long be included as a devp2p capability/
subprotocol for the node.

This commit changes that, and enables the eth service to return multiple
subprotocols, e.g. "eth", "istanbul/100".

"istanbul/100" has been added as a new istanbul subprotocol version, which supports
the multple subprotocols design. peers running older versions of istanbul will
continue to override the "eth" service and will communicate over a single subprotocol:

istanbul/99 <-> istanbul/99
istanbul/100, eth <-> istanbul/100, eth

To maintain backwards compatibility, when establishing a connection with a
new peer that does not support multiple protocols, but rather a "legacy"
protocol, e.g. "istanbul/64" "istanbul/99" "clique" (v2.6), the nodes will communicate
over the single "legacy" protocol and not "eth" + consensus subprotocol.

When running two subprotocols, "eth" + "consensus", the eth subprotocol
manages the lifecycle of the peer for the eth service, and the consensus
subprotocol uses this peer for its communication, registering a separate
protocol read writer on it.

maintains backwards compatibility with: istanbul, raft, clique.