### PR TITLE
Count consensus messages and change to prepare state handling commit

### DIFF
--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -57,7 +57,7 @@ func (c *core) handlePrepare(msg *message, src istanbul.Validator) error {
 
 	c.acceptPrepare(msg, src)
 
-	// Change to Prepared state if we've received enough PREPARE messages or it is locked
+	// Change to Prepared state if we've received enough PREPARE/COMMIT messages or it is locked
 	// and we are in earlier state before Prepared state.
 	if ((c.current.IsHashLocked() && prepare.Digest == c.current.GetLockedHash()) || c.current.GetPrepareOrCommitSize() >= c.QuorumSize()) &&
 		c.state.Cmp(StatePrepared) < 0 {


### PR DESCRIPTION
Istanbul BFT could fail to achieve a consensus on a hash-locked proposal depends on the consensus message order.
With this change, the problem can be resolved. The detail about the problem is described in https://github.com/ConsenSys/quorum/issues/1133 

Resolve https://github.com/ConsenSys/quorum/issues/1133