### PR TITLE
[Fix] Use right checkout action version to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         # ###[error]    natupnp_test.go:165: not discovered
         # must be sommething with Github Actions VM networking setup.
         # Event Ubuntu requires a workaround
-        os: ["ubuntu-18.04"]
+        os: [ "ubuntu-18.04" ]
     env:
       QUORUM_IGNORE_TEST_PACKAGES: github.com/ethereum/go-ethereum/les,github.com/ethereum/go-ethereum/les/flowcontrol,github.com/ethereum/go-ethereum/mobile
     runs-on: ${{ matrix.os }}
@@ -33,7 +33,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: 'Check out project files'
-        uses: actions/checkout@574281d
+        uses: actions/checkout@v2
         with:
           submodules: recursive
           path: ${{ env.WORKING_DIR }}


### PR DESCRIPTION
Update to the right checkout action version as the other configurations are using (PR & Release)