### PR TITLE
[Fix] Wrong order when checking the privacy block in the genesis file against stored config

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -238,14 +238,18 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 	if height == nil {
 		return newcfg, stored, fmt.Errorf("missing block number for head header hash")
 	}
+
+	// Quorum
+	if storedcfg.PrivacyEnhancementsBlock == nil {
+		checkAndPrintPrivacyEnhancementsWarning(newcfg)
+	}
+	// End Quorum
+
 	compatErr := storedcfg.CheckCompatible(newcfg, *height, rawdb.GetIsQuorumEIP155Activated(db))
 	if compatErr != nil && *height != 0 && compatErr.RewindTo != 0 {
 		return newcfg, stored, compatErr
 	}
 	rawdb.WriteChainConfig(db, stored, newcfg)
-	if storedcfg.PrivacyEnhancementsBlock == nil {
-		checkAndPrintPrivacyEnhancementsWarning(newcfg)
-	}
 	return newcfg, stored, nil
 }
 


### PR DESCRIPTION
### Summary

There was an issue with the order when calling `checkAndPrintPrivacyEnhancementsWarning` inside the `SetupGenesisBlock`.

This created an issue in the AT `Partial Network upgrade from an old version (q2.5.0/t0.10.5) to privacy enhancements enabled version of geth and tessera ` as the test was expecting that message to come before the fatal error.

Introduced by https://github.com/ConsenSys/quorum/pull/1130.

### Changes

* Change order of `checkAndPrintPrivacyEnhancementsWarning` check