### PR TITLE
Only initialise PTM for nodes

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -152,10 +152,6 @@ func enableWhisper(ctx *cli.Context) bool {
 
 // makeFullNode loads geth configuration and creates the Ethereum backend.
 func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
-	if err := quorumInitialisePrivacy(ctx); err != nil {
-		utils.Fatalf("Error initialising Private Transaction Manager: %s", err.Error())
-	}
-
 	stack, cfg := makeConfigNode(ctx)
 
 	// Quorum - returning `ethService` too for the Raft and extension service
@@ -174,6 +170,11 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 	if ctx.GlobalBool(utils.RaftModeFlag.Name) {
 		utils.RegisterRaftService(stack, ctx, &cfg.Node, ethService)
+	}
+
+	//Must occur before registering the extension service, as it needs an initialised PTM to be enabled
+	if err := quorumInitialisePrivacy(ctx); err != nil {
+		utils.Fatalf("Error initialising Private Transaction Manager: %s", err.Error())
 	}
 
 	if private.IsQuorumPrivacyEnabled() {

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common/http"
 	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/extension/privacyExtension"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -151,6 +152,10 @@ func enableWhisper(ctx *cli.Context) bool {
 
 // makeFullNode loads geth configuration and creates the Ethereum backend.
 func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
+	if err := quorumInitialisePrivacy(ctx); err != nil {
+		utils.Fatalf("Error initialising Private Transaction Manager: %s", err.Error())
+	}
+
 	stack, cfg := makeConfigNode(ctx)
 
 	// Quorum - returning `ethService` too for the Raft and extension service
@@ -262,6 +267,22 @@ func quorumValidatePrivacyEnhancements(ethereum *eth.Ethereum) {
 			utils.Fatalf("Cannot start quorum with privacy enhancements enabled while the transaction manager does not support it")
 		}
 	}
+}
+
+// configure and set up quorum transaction privacy
+func quorumInitialisePrivacy(ctx *cli.Context) error {
+	cfg, err := QuorumSetupPrivacyConfiguration(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = private.InitialiseConnection(cfg)
+	if err != nil {
+		return err
+	}
+	privacyExtension.Init()
+
+	return nil
 }
 
 // Get private transaction manager configuration

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/extension/privacyExtension"
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/internal/flags"
@@ -48,7 +47,6 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/permission"
 	"github.com/ethereum/go-ethereum/plugin"
-	"github.com/ethereum/go-ethereum/private"
 	gopsutil "github.com/shirou/gopsutil/mem"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -298,37 +296,13 @@ func init() {
 	app.Flags = append(app.Flags, metricsFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
-		if err := debug.Setup(ctx); err != nil {
-			return err
-		}
-
-		if err := quorumInitialisePrivacy(ctx); err != nil {
-			return err
-		}
-
-		return nil
+		return debug.Setup(ctx)
 	}
 	app.After = func(ctx *cli.Context) error {
 		debug.Exit()
 		prompt.Stdin.Close() // Resets terminal mode.
 		return nil
 	}
-}
-
-// configure and set up quorum transaction privacy
-func quorumInitialisePrivacy(ctx *cli.Context) error {
-	cfg, err := QuorumSetupPrivacyConfiguration(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = private.InitialiseConnection(cfg)
-	if err != nil {
-		return err
-	}
-	privacyExtension.Init()
-
-	return nil
 }
 
 func main() {


### PR DESCRIPTION
When starting up Quorum subcommands (e.g. account creation, console attaching), the PTM gets initialised and outputs a log message stating the private tens are disabled, since the user would not have set the PRIVATE_CONFIG envvar for these operations.
This misleads users into thinking the node they are actually running is not enabled to use private transactions, which is not the case.

This PR moves the initialisation to only when running an actual node instance, and stops the log message being output when not needed.