### PR TITLE
Fix generation of Cloudsmith URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
   draft-release:
     name: 'Draft Github release'
     needs:
-      - deploy-bintray
+      - deploy-cloudsmith
       - publish-docker
     runs-on: ubuntu-18.04
     steps:
@@ -108,8 +108,6 @@ jobs:
         id: release_notes
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          package="${{ secrets.BINTRAY_PACKAGE }}"
-          repo="${package%/*}"
           file="generated-release-notes.md"
           current_version="${GITHUB_REF##*/}"
           last_version=$(git describe --abbrev=0 --tags `git rev-list --tags --skip=1  --max-count=1`)
@@ -119,13 +117,16 @@ jobs:
           curl -q -s -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/search/issues?q=repo:ConsenSys/quorum+is:pr+is:merged+merged%3A>=$last_release_date+sort%3Aupdated-desc" | jq -r '"* " + (.items[]|.title + " #" + (.number|tostring))' \
             >> $file
-          # pulling file hashes from Bintray
+          # pulling file hashes from Cloudsmith
           echo "" >> $file
           echo "| Filename | SHA256 Hash |" >> $file
           echo "|:---------|:------------|" >> $file
-          curl -q -s -u ${{ secrets.BINTRAY_USER }}:${{ secrets.BINTRAY_API_KEY}} "https://api.bintray.com/packages/$package/versions/$current_version/files" \
-          	| jq '.[] | select(.name | endswith(".asc") | not) | "|[\(.name)](https://bintray.com/'"$repo"'/download_file?file_path=\(.path))|`\(.sha256)`|"' -r \
-          	>> $file
+          curl --request GET \
+            --url "https://api.cloudsmith.io/v1/packages/consensys/go-quorum/?query=version:$current_version" \
+            --header 'Accept: application/json' \
+            --header 'X-Api-Key: ${{ secrets.CLOUDSMITH_API_KEY }}' \
+                    	| jq '.[] | select(.name | endswith(".asc") | not) | "|[\(.name)](\(.cdn_url))|`\(.checksum_sha256)`|"' -r \
+                    	>> $file
           content=$(cat $file)
           # escape newline
           content="${content//'%'/'%25'}"
@@ -149,7 +150,7 @@ jobs:
     name: 'Notify'
     needs:
       - build
-      - deploy-bintray
+      - deploy-cloudsmith
       - publish-docker
       - draft-release
     runs-on: ubuntu-18.04


### PR DESCRIPTION
### Changes

* Fix job dependency naming
* Fix generation of URL from cloudsmith:
    ```
    |[geth_v21.1.0_darwin_amd64.tar.gz](https://artifacts.consensys.net/public/go-quorum/raw/versions/v21.1.0/geth_v21.1.0_darwin_amd64.tar.gz)|`2278a9fce0a5095f56ab8ef430a157e8aef3c48697e33256989ecfc758f499a2`|
    |[geth_v21.1.0_linux_amd64.tar.gz](https://artifacts.consensys.net/public/go-quorum/raw/versions/v21.1.0/geth_v21.1.0_linux_amd64.tar.gz)|`b5aead4958a10cbd6cb69308930720a67cf6789d5f2c500b626fcb410871844f`|
    ```