### PR TITLE
plugin: use Cloudsmith to download plugins

### DIFF
--- a/plugin/central.go
+++ b/plugin/central.go
@@ -10,7 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
+	"text/template"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -54,37 +57,41 @@ func (cc *CentralClient) getNewSecureDialer() Dialer {
 	}
 }
 
-// Get the public key from central
+// Get the public key from central. PublicKeyURI can be relative to the base URL
+// so we need to parse and make sure finally URL is resolved.
 func (cc *CentralClient) PublicKey() ([]byte, error) {
-	target := fmt.Sprintf("%s/%s", cc.config.BaseURL, cc.config.PublicKeyURI)
-	log.Debug("downloading public key", "url", target)
-	readCloser, err := cc.get(target)
+	target, err := cc.toURL(cc.config.PublicKeyURI)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = readCloser.Close()
-	}()
-	return ioutil.ReadAll(readCloser)
+	log.Debug("downloading public key", "url", target)
+	buf := new(bytes.Buffer)
+	if err := cc.download(target, buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // retrieve plugin signature
 func (cc *CentralClient) PluginSignature(definition *PluginDefinition) ([]byte, error) {
-	target := fmt.Sprintf("%s/%s/%s", cc.config.BaseURL, definition.RemotePath(), definition.SignatureFileName())
-	log.Debug("downloading plugin signature file", "url", target)
-	readCloser, err := cc.get(target)
+	target, err := cc.toURLFromTemplate(cc.config.PluginSigPathTemplate, definition)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = readCloser.Close()
-	}()
-	return ioutil.ReadAll(readCloser)
+	log.Debug("downloading plugin signature file", "url", target)
+	buf := new(bytes.Buffer)
+	if err := cc.download(target, buf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // retrieve plugin distribution file
 func (cc *CentralClient) PluginDistribution(definition *PluginDefinition, outFilePath string) error {
-	target := fmt.Sprintf("%s/%s/%s", cc.config.BaseURL, definition.RemotePath(), definition.DistFileName())
+	target, err := cc.toURLFromTemplate(cc.config.PluginDistPathTemplate, definition)
+	if err != nil {
+		return err
+	}
 	log.Debug("downloading plugin zip file", "url", target)
 	outFile, err := os.Create(outFilePath)
 	if err != nil {
@@ -93,15 +100,7 @@ func (cc *CentralClient) PluginDistribution(definition *PluginDefinition, outFil
 	defer func() {
 		_ = outFile.Close()
 	}()
-	readCloser, err := cc.get(target)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = readCloser.Close()
-	}()
-	_, err = io.Copy(outFile, readCloser)
-	return err
+	return cc.download(target, outFile)
 }
 
 // perform HTTP GET
@@ -123,6 +122,59 @@ func (cc *CentralClient) get(target string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("HTTP GET error: code=%d, status=%s, body=%s", res.StatusCode, res.Status, string(data))
 	}
 	return res.Body, nil
+}
+
+// return full URL using config.BaseURL
+func (cc *CentralClient) toURL(relativePath string) (string, error) {
+	base, err := url.Parse(cc.config.BaseURL)
+	if err != nil {
+		return "", err
+	}
+	u, err := base.Parse(relativePath)
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}
+
+// return full URL using config.BaseURL from given template
+func (cc *CentralClient) toURLFromTemplate(pathTemplate string, definition *PluginDefinition) (string, error) {
+	t, err := template.New("").Parse(pathTemplate)
+	if err != nil {
+		return "", err
+	}
+	path := new(bytes.Buffer)
+	if err := t.Execute(path, struct {
+		Name    string
+		Version string
+		OS      string
+		Arch    string
+	}{
+		Name:    definition.Name,
+		Version: string(definition.Version),
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+	}); err != nil {
+		return "", err
+	}
+	return cc.toURL(path.String())
+}
+
+// peform http GET to the target URL and write output to out
+func (cc *CentralClient) download(target string, out io.Writer) (err error) {
+	defer func(start time.Time) {
+		log.Debug("download completed", "url", target, "err", err, "took", time.Since(start))
+	}(time.Now())
+	var readCloser io.ReadCloser
+	readCloser, err = cc.get(target)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = readCloser.Close()
+	}()
+	_, err = io.Copy(out, readCloser)
+	return err
 }
 
 // An adapter function for tls.Dial with CA verification & SSL Pinning support.

--- a/plugin/downloader_test.go
+++ b/plugin/downloader_test.go
@@ -1,9 +1,11 @@
 package plugin
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +19,7 @@ func TestDownloader_Download_whenPluginIsAvailableLocally(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tmpDir)
 	}()
-	arbitraryPluginDistPath := path.Join(tmpDir, "arbitrary-plugin-1.0.0.zip")
+	arbitraryPluginDistPath := path.Join(tmpDir, fmt.Sprintf("arbitrary-plugin-1.0.0-%s-%s.zip", runtime.GOOS, runtime.GOARCH))
 	if err := ioutil.WriteFile(arbitraryPluginDistPath, []byte{}, 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/local_verifier.go
+++ b/plugin/local_verifier.go
@@ -7,7 +7,9 @@ import (
 	"path"
 )
 
-const DefaultPublicKeyFile = "Central.pgp.pk"
+// For Cloudsmith, this references to the latest GPG key
+// being setup in the repo
+const DefaultPublicKeyFile = "gpg.key"
 
 // Local Implementation of plugin.Verifier
 type LocalVerifier struct {

--- a/plugin/service_test.go
+++ b/plugin/service_test.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/go-plugin"
@@ -47,8 +49,8 @@ func TestPluginManager_ProvidersPopulation(t *testing.T) {
 	}, false, false, "")
 
 	testifyassert.NoError(t, err)
-	testifyassert.Equal(t, "arbitrary-helloWorld-1.0.0", testObject.initializedPlugins[HelloWorldPluginInterfaceName].(*basePlugin).pluginDefinition.FullName())
-	testifyassert.Equal(t, "foo-bar-2.0.0", testObject.initializedPlugins[arbitraryPluginInterfaceName].(*basePlugin).pluginDefinition.FullName())
+	testifyassert.Equal(t, fmt.Sprintf("arbitrary-helloWorld-1.0.0-%s-%s", runtime.GOOS, runtime.GOARCH), testObject.initializedPlugins[HelloWorldPluginInterfaceName].(*basePlugin).pluginDefinition.FullName())
+	testifyassert.Equal(t, fmt.Sprintf("foo-bar-2.0.0-%s-%s", runtime.GOOS, runtime.GOARCH), testObject.initializedPlugins[arbitraryPluginInterfaceName].(*basePlugin).pluginDefinition.FullName())
 }
 
 func TestPluginManager_GetPluginTemplate_whenTypical(t *testing.T) {


### PR DESCRIPTION
- update default configuration pointing to Cloudsmith
- change path to download plugin
- allow custom path templates for plugin dist and sig files. Templates are Go text templates supporting the self-explanatory variables:  \{\{.Name\}\}, \{\{.Version\}\}, \{\{.OS\}\} and \{\{.Arch\}\}