### PR TITLE
[Fix] core/rawdb: Remove hash check before return data from ancient db

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -274,9 +273,14 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 	// comparison is necessary since ancient database only maintains
 	// the canonical data.
 	data, _ := db.Ancient(freezerHeaderTable, number)
-	if len(data) > 0 && crypto.Keccak256Hash(data) == hash {
+
+	// Quorum
+	// Removed `crypto.Keccak256Hash(data) == hash` check as the data will include istanbul headers and wont result in the same hash (check core/types/block.go:106 for more info)
+	if len(data) > 0 {
 		return data
 	}
+	// End Quorum
+
 	// Then try to look up the data in leveldb.
 	data, _ = db.Get(headerKey(number, hash))
 	if len(data) > 0 {
@@ -287,9 +291,14 @@ func ReadHeaderRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValu
 	// but when we reach into leveldb, the data was already moved. That would
 	// result in a not found error.
 	data, _ = db.Ancient(freezerHeaderTable, number)
-	if len(data) > 0 && crypto.Keccak256Hash(data) == hash {
+
+	// Quorum
+	// Removed `crypto.Keccak256Hash(data) == hash` check as the data will include istanbul headers and wont result in the same hash (check core/types/block.go:106 for more info)
+	if len(data) > 0 {
 		return data
 	}
+	// End Quorum
+
 	return nil // Can't find the data anywhere.
 }
 

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -412,9 +412,14 @@ func TestAncientStorage(t *testing.T) {
 	}
 	// Use a fake hash for data retrieval, nothing should be returned.
 	fakeHash := common.BytesToHash([]byte{0x01, 0x02, 0x03})
-	if blob := ReadHeaderRLP(db, fakeHash, number); len(blob) != 0 {
-		t.Fatalf("invalid header returned")
+
+	// Quorum
+	// We skip the hash `crypto.Keccak256Hash(data)` check
+	if blob := ReadHeaderRLP(db, fakeHash, number); len(blob) == 0 {
+		t.Fatalf("invalid header returned, should return a valid blob as we don't verify the hash")
 	}
+	// End Quorum
+
 	if blob := ReadBodyRLP(db, fakeHash, number); len(blob) != 0 {
 		t.Fatalf("invalid body returned")
 	}


### PR DESCRIPTION
### Summary

Base Geth Ancient DB performs a block header hash check each time it retrieves a block from filesytem. It does so by computing the hash of the raw rlp encoded block stored data.

This leads to an issue when running on IBFT for which block header hash is not equal to the raw rlp encoded block data hash. 

To avoid this issue we remove the hash check.

Fixes #1179

### Changes

* Remove hash check