### PR TITLE
[Fix] Use right block number when checking the current block number on gas estimation

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1178,8 +1178,10 @@ func DoEstimateGas(ctx context.Context, b Backend, args CallArgs, blockNrOrHash 
 
 	//if the transaction has a value then it cannot be private, so we can skip this check
 	if args.Value != nil && args.Value.ToInt().Cmp(big.NewInt(0)) == 0 {
-		homestead := b.ChainConfig().IsHomestead(new(big.Int).SetInt64(int64(rpc.PendingBlockNumber)))
-		istanbul := b.ChainConfig().IsIstanbul(new(big.Int).SetInt64(int64(rpc.PendingBlockNumber)))
+		currentBlockHeight := b.CurrentHeader().Number
+		homestead := b.ChainConfig().IsHomestead(currentBlockHeight)
+		istanbul := b.ChainConfig().IsIstanbul(currentBlockHeight)
+
 		var data []byte
 		if args.Data == nil {
 			data = nil

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/math"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -40,7 +42,20 @@ var (
 		PrivateFrom: arbitraryPrivateFrom,
 		PrivateFor:  []string{"arbitrary party 1", "arbitrary party 2"},
 	}
-	arbitraryFrom = common.BytesToAddress([]byte("arbitrary address"))
+	arbitraryFrom         = common.BytesToAddress([]byte("arbitrary address"))
+	arbitraryTo           = common.BytesToAddress([]byte("arbitrary address to"))
+	arbitraryGas          = uint64(200000)
+	arbitraryZeroGasPrice = big.NewInt(0)
+	arbitraryZeroValue    = big.NewInt(0)
+	arbitraryEmptyData    = new([]byte)
+	callTxArgs            = CallArgs{
+		From:     &arbitraryFrom,
+		To:       &arbitraryTo,
+		Gas:      (*hexutil.Uint64)(&arbitraryGas),
+		GasPrice: (*hexutil.Big)(arbitraryZeroGasPrice),
+		Value:    (*hexutil.Big)(arbitraryZeroValue),
+		Data:     (*hexutil.Bytes)(arbitraryEmptyData),
+	}
 
 	arbitrarySimpleStorageContractEncryptedPayloadHash = common.BytesToEncryptedPayloadHash([]byte("arbitrary payload hash"))
 
@@ -131,6 +146,24 @@ func setup() {
 
 func teardown() {
 	log.Root().SetHandler(log.DiscardHandler())
+}:w
+
+func TestDoEstimateGas_whenNoValueTx_Homestead(t *testing.T) {
+	assert := assert.New(t)
+
+	estimation, err := DoEstimateGas(arbitraryCtx, &StubBackend{CurrentHeadNumber: big.NewInt(10)}, callTxArgs, rpc.BlockNumberOrHashWithNumber(10), math.MaxInt64)
+
+	assert.NoError(err, "gas estimation")
+	assert.Equal(hexutil.Uint64(25352), estimation, "estimation for a public or private tx")
+}
+
+func TestDoEstimateGas_whenNoValueTx_Istanbul(t *testing.T) {
+	assert := assert.New(t)
+
+	estimation, err := DoEstimateGas(arbitraryCtx, &StubBackend{IstanbulBlock: big.NewInt(0), CurrentHeadNumber: big.NewInt(10)}, callTxArgs, rpc.BlockNumberOrHashWithNumber(10), math.MaxInt64)
+
+	assert.NoError(err, "gas estimation")
+	assert.Equal(hexutil.Uint64(22024), estimation, "estimation for a public or private tx")
 }
 
 func TestSimulateExecution_whenStandardPrivateCreation(t *testing.T) {
@@ -450,10 +483,13 @@ func TestHandlePrivateTransaction_whenRawStandardPrivateMessageCall(t *testing.T
 type StubBackend struct {
 	getEVMCalled                    bool
 	mockAccountExtraDataStateGetter *vm.MockAccountExtraDataStateGetter
+
+	IstanbulBlock     *big.Int
+	CurrentHeadNumber *big.Int
 }
 
 func (sb *StubBackend) CurrentHeader() *types.Header {
-	panic("implement me")
+	return &types.Header{Number: sb.CurrentHeadNumber}
 }
 
 func (sb *StubBackend) Engine() consensus.Engine {
@@ -461,7 +497,7 @@ func (sb *StubBackend) Engine() consensus.Engine {
 }
 
 func (sb *StubBackend) SupportsMultitenancy(rpcCtx context.Context) (*proto.PreAuthenticatedAuthenticationToken, bool) {
-	panic("implement me")
+	return nil, false
 }
 
 func (sb *StubBackend) AccountExtraDataStateGetterByNumber(context.Context, rpc.BlockNumber) (vm.AccountExtraDataStateGetter, error) {
@@ -481,7 +517,12 @@ func (sb *StubBackend) GetEVM(ctx context.Context, msg core.Message, state vm.Mi
 		Difficulty: big.NewInt(0),
 		GasLimit:   0,
 	}, nil, &arbitraryFrom)
-	return vm.NewEVM(vmCtx, publicStateDB, privateStateDB, params.QuorumTestChainConfig, vm.Config{}), nil, nil
+	vmError := func() error {
+		return nil
+	}
+	config := params.QuorumTestChainConfig
+	config.IstanbulBlock = sb.IstanbulBlock
+	return vm.NewEVM(vmCtx, publicStateDB, privateStateDB, config, vm.Config{}), vmError, nil
 }
 
 func (sb *StubBackend) CurrentBlock() *types.Block {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -146,7 +146,7 @@ func setup() {
 
 func teardown() {
 	log.Root().SetHandler(log.DiscardHandler())
-}:w
+}
 
 func TestDoEstimateGas_whenNoValueTx_Homestead(t *testing.T) {
 	assert := assert.New(t)

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -148,7 +148,7 @@ func teardown() {
 	log.Root().SetHandler(log.DiscardHandler())
 }
 
-func TestDoEstimateGas_whenNoValueTx_Homestead(t *testing.T) {
+func TestDoEstimateGas_whenNoValueTx_Pre_Istanbul(t *testing.T) {
 	assert := assert.New(t)
 
 	estimation, err := DoEstimateGas(arbitraryCtx, &StubBackend{CurrentHeadNumber: big.NewInt(10)}, callTxArgs, rpc.BlockNumberOrHashWithNumber(10), math.MaxInt64)


### PR DESCRIPTION
## Summary

The quorum specific code that takes into account the possibility of a zero value tx could be public or private had a bug which it was not checking the right block number when the configuration had `istanbulBlock` as 0.

Original fix by @prd-fox 

## Changes

* Use current header to get current block number
* Add unit test


## References

Merge after https://github.com/ConsenSys/quorum-acceptance-tests/pull/101