### PR TITLE
go.mod: remove replace crypto package

### DIFF
--- a/crypto/secp256k1/go.mod
+++ b/crypto/secp256k1/go.mod
@@ -1,3 +1,0 @@
-module github.com/ConsenSys/quorum/crypto/secp256k1
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,7 @@ module github.com/ethereum/go-ethereum
 go 1.15
 
 // Quorum - Replace Go modules that use modifications done by us
-replace (
-	github.com/coreos/etcd => github.com/Consensys/etcd v3.3.13-quorum197+incompatible
-	github.com/ethereum/go-ethereum/crypto/secp256k1 => ./crypto/secp256k1
-)
+replace github.com/coreos/etcd => github.com/Consensys/etcd v3.3.13-quorum197+incompatible
 
 // End Quorum
 
@@ -34,7 +31,6 @@ require (
 	github.com/eapache/channels v1.1.0
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/edsrzf/mmap-go v0.0.0-20160512033002-935e0e8a636c
-	github.com/ethereum/go-ethereum/crypto/secp256k1 v0.0.0
 	github.com/fatih/color v1.7.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/Azure/go-autorest/tracing v0.5.0 h1:TRn4WjSnkcSy5AEG3pnbtFSwNtwzjr4VY
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/ConsenSys/quorum/crypto/secp256k1 v0.0.0-20210223160031-6e8585c2a9ad h1:04hKIfJWbJFYtNFeI77cRzfiEpNT9f44KNdHhB6sGOw=
-github.com/ConsenSys/quorum/crypto/secp256k1 v0.0.0-20210223160031-6e8585c2a9ad/go.mod h1:mrsI3XgXEfdgdT37sIJiqEha0aOBGreMcc1fbu7aDEw=
 github.com/Consensys/etcd v3.3.13-quorum197+incompatible h1:ZBM9sH4QEufgaShSyNNhffuZv6Zhl5kyD2b/NHViByM=
 github.com/Consensys/etcd v3.3.13-quorum197+incompatible/go.mod h1:wz4o/jwsTgMkSZUY9DmwVEIL3b2JX3t+tCDdy/J5ilY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -116,7 +114,6 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26 h1:lMm2hD9Fy0ynom5+85/pbdkiYcBqM1JWmhpAXLmy0fw=
 github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=


### PR DESCRIPTION
Remove `github.com/ethereum/go-ethereum/crypto/secp256k1 => ./crypto/secp256k1` replace in `go.mod` to avoid issues when importing GoQ. packages