### PR TITLE
Check if sb.core is nil before processing NewBlockMsg

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -103,7 +103,7 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg) (bool, error) {
 	}
 	//https://github.com/ConsenSys/quorum/pull/539
 	//https://github.com/ConsenSys/quorum/issues/389
-	if msg.Code == NewBlockMsg && sb.core.IsProposer() { // eth.NewBlockMsg: import cycle
+	if msg.Code == NewBlockMsg && sb.core != nil && sb.core.IsProposer() { // eth.NewBlockMsg: import cycle
 		// this case is to safeguard the race of similar block which gets propagated from other node while this node is proposing
 		// as p2p.Msg can only be decoded once (get EOF for any subsequence read), we need to make sure the payload is restored after we decode it
 		sb.logger.Debug("BFT: received NewBlockMsg", "size", msg.Size, "payload.type", reflect.TypeOf(msg.Payload), "sender", addr)


### PR DESCRIPTION
A non-mining, non-validator node does not have istanbul backend core set. When a `p2p` message of code corresponding `NewBlockMsg` is received it checks if that node is a proposer. As backend core is nil, this results in a panic. This PR adds a check to see if core is nil and only processes the message is it is not nil, which should be the case for a mining node