### PR TITLE
Asynchronously call startNewRound() when transitioning from IBFT to QBFT

### DIFF
--- a/consensus/istanbul/ibft/core/final_committed.go
+++ b/consensus/istanbul/ibft/core/final_committed.go
@@ -16,11 +16,23 @@
 
 package core
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 func (c *core) handleFinalCommitted() error {
 	logger := c.logger.New("state", c.state)
 	logger.Trace("Received a final committed proposal")
-	go c.startNewRound(common.Big0)
+
+	// startNewRound() needs to be called asynchronously when the transition to qbft happens
+	// This is required so that the stop() on core can successfully unsubscribe from events
+	nextSeq := new(big.Int).Add(c.currentView().Sequence, big.NewInt(1))
+	if c.backend.IsQBFTConsensusAt(nextSeq) {
+		go c.startNewRound(common.Big0)
+	} else {
+		c.startNewRound(common.Big0)
+	}
 	return nil
 }


### PR DESCRIPTION
When transitioning from Legacy IBFT to QBFT consensus `startNewRound()` needs to be called asynchronously, so that `stop()` on `core` can successfully unsubscribe from events. During normal IBFT consensus flow, `startNewRound()` should be called synchronously which was the case prior to QBFT changes