### PR TITLE
Amend IntrinsicGas calculation for Privacy Marker Transaction to use actual payload hash, instead of hardcoded value

### DIFF
--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -448,7 +448,7 @@ func (c *BoundContract) createMarkerTx(opts *TransactOpts, tx *types.Transaction
 	}
 
 	// Note: using isHomestead and isEIP2028 set to true, which may give a slightly higher gas value (but avoids making an API call to get the block number)
-	intrinsicGas, err := core.IntrinsicGas(common.Hex2Bytes(common.MaxPrivateIntrinsicDataHex), false, true, true)
+	intrinsicGas, err := core.IntrinsicGas(common.FromHex(hash), false, true, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2876,7 +2876,7 @@ func createPrivacyMarkerTransaction(b Backend, privateTx *types.Transaction, pri
 
 	currentBlockHeight := b.CurrentHeader().Number
 	istanbul := b.ChainConfig().IsIstanbul(currentBlockHeight)
-	intrinsicGas, err := core.IntrinsicGas(common.Hex2Bytes(common.MaxPrivateIntrinsicDataHex), false, true, istanbul)
+	intrinsicGas, err := core.IntrinsicGas(ptmHash.Bytes(), false, true, istanbul)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Minor amendment to the merged privacy precompile changes.