### PR TITLE
Protect ProposerPolicy Registry using Mutex

### DIFF
--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -169,7 +169,6 @@ func TestSealStopChannel(t *testing.T) {
 		stop <- struct{}{}
 		eventSub.Unsubscribe()
 	}
-	go eventLoop()
 	resultCh := make(chan *types.Block, 10)
 	go func() {
 		err := engine.Seal(chain, block, resultCh, stop)
@@ -177,6 +176,7 @@ func TestSealStopChannel(t *testing.T) {
 			t.Errorf("error mismatch: have %v, want nil", err)
 		}
 	}()
+	go eventLoop()
 
 	finalBlock := <-resultCh
 	if finalBlock != nil {

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -211,7 +211,7 @@ func (s *Snapshot) UnmarshalJSON(b []byte) error {
 	s.Tally = j.Tally
 
 	// Setting the By function to ValidatorSortByStringFunc should be fine, as the validator do not change only the order changes
-	pp := &istanbul.ProposerPolicy{Id: j.Policy, By: istanbul.ValidatorSortByString()}
+	pp := istanbul.NewProposerPolicyByIdAndSortFunc(j.Policy, istanbul.ValidatorSortByString())
 	s.ValSet = validator.NewSet(j.Validators, pp)
 	return nil
 }


### PR DESCRIPTION
`RegisterValidatorSet()` might throw a nil pointer, if the `validatorSet` registry is cleared in `ClearRegistry()` by another goroutine. To fix this access to `registry` needs to be protected.