### PR TITLE
fix: flacky unit test

### DIFF
--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
@@ -84,8 +85,15 @@ func TestHandleNewBlockMessage_whenTypical(t *testing.T) {
 	arbitraryBlock, arbitraryP2PMessage := buildArbitraryP2PNewBlockMessage(t, false)
 	postAndWait(backend, arbitraryBlock, t)
 
-	handled, err := backend.HandleMsg(arbitraryAddress, arbitraryP2PMessage)
-
+	var handled bool
+	var err error
+	for i := 0; i < 5; i++ { // make 5 tries if a little wait
+		handled, err = backend.HandleMsg(arbitraryAddress, arbitraryP2PMessage)
+		if handled && err == nil {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if err != nil {
 		t.Errorf("expected message being handled successfully but got %s", err)
 	}
@@ -109,8 +117,15 @@ func TestHandleNewBlockMessage_whenNotAProposedBlock(t *testing.T) {
 		MixDigest: types.IstanbulDigest,
 	}, nil, nil, nil, new(trie.Trie)), t)
 
-	handled, err := backend.HandleMsg(arbitraryAddress, arbitraryP2PMessage)
-
+	var handled bool
+	var err error
+	for i := 0; i < 5; i++ { // make 5 tries if a little wait
+		handled, err = backend.HandleMsg(arbitraryAddress, arbitraryP2PMessage)
+		if handled && err == nil {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if err != nil {
 		t.Errorf("expected message being handled successfully but got %s", err)
 	}
@@ -133,8 +148,15 @@ func TestHandleNewBlockMessage_whenFailToDecode(t *testing.T) {
 		MixDigest: types.IstanbulDigest,
 	}, nil, nil, nil, new(trie.Trie)), t)
 
-	handled, err := backend.HandleMsg(arbitraryAddress, arbitraryP2PMessage)
-
+	var handled bool
+	var err error
+	for i := 0; i < 5; i++ { // make 5 tries if a little wait
+		handled, err = backend.HandleMsg(arbitraryAddress, arbitraryP2PMessage)
+		if handled && err == nil {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
 	if err != nil {
 		t.Errorf("expected message being handled successfully but got %s", err)
 	}

--- a/consensus/istanbul/ibft/core/handler.go
+++ b/consensus/istanbul/ibft/core/handler.go
@@ -28,6 +28,7 @@ func (c *core) Start() error {
 	// Tests will handle events itself, so we have to make subscribeEvents()
 	// be able to call in test.
 	c.subscribeEvents()
+	c.handlerWg.Add(1)
 	go c.handleEvents()
 
 	// Start a new round from last sequence + 1
@@ -78,7 +79,6 @@ func (c *core) handleEvents() {
 		c.handlerWg.Done()
 	}()
 
-	c.handlerWg.Add(1)
 	for {
 		select {
 		case event, ok := <-c.events.Chan():

--- a/consensus/istanbul/qbft/core/handler.go
+++ b/consensus/istanbul/qbft/core/handler.go
@@ -33,6 +33,7 @@ func (c *core) Start() error {
 	// Tests will handle events itself, so we have to make subscribeEvents()
 	// be able to call in test.
 	c.subscribeEvents()
+	c.handlerWg.Add(1)
 	go c.handleEvents()
 
 	// Start a new round from last sequence + 1
@@ -97,7 +98,6 @@ func (c *core) handleEvents() {
 		c.handlerWg.Done()
 	}()
 
-	c.handlerWg.Add(1)
 	for {
 		select {
 		case event, ok := <-c.events.Chan():


### PR DESCRIPTION
1. wait group add should be outside the go routine
2. it's not possible to have a event that the message has just been handled, so the test may happen too soon.