### PR TITLE
Upstream merge fixes

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -113,7 +113,7 @@ func init() {
 		PrecompiledAddressesHomestead = append(PrecompiledAddressesHomestead, k)
 	}
 	for k := range PrecompiledContractsByzantium {
-		PrecompiledAddressesHomestead = append(PrecompiledAddressesByzantium, k)
+		PrecompiledAddressesByzantium = append(PrecompiledAddressesByzantium, k)
 	}
 	for k := range PrecompiledContractsIstanbul {
 		PrecompiledAddressesIstanbul = append(PrecompiledAddressesIstanbul, k)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -60,6 +60,13 @@ type (
 // ActivePrecompiles returns the addresses of the precompiles enabled with the current
 // configuration
 func (evm *EVM) ActivePrecompiles() []common.Address {
+	return append(evm.activePrecompiles(), evm.activeQuorumPrecompiles()...)
+}
+
+// (Quorum) moved upstream ActivePrecompiles() logic to new method activePrecompiles()
+// This functionality is part of an experimental feature so may be subject to future changes. Keeping the original code
+// untouched in a new method should flag any changes from future merges.
+func (evm *EVM) activePrecompiles() []common.Address {
 	switch {
 	case evm.chainRules.IsYoloV2:
 		return PrecompiledAddressesYoloV2
@@ -70,6 +77,14 @@ func (evm *EVM) ActivePrecompiles() []common.Address {
 	default:
 		return PrecompiledAddressesHomestead
 	}
+}
+
+func (evm *EVM) activeQuorumPrecompiles() []common.Address {
+	var p []common.Address
+	if evm.chainRules.IsPrivacyPrecompile {
+		p = append(p, common.QuorumPrivacyPrecompileContractAddress())
+	}
+	return p
 }
 
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -1,0 +1,97 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivePrecompiles(t *testing.T) {
+	tests := []struct {
+		name string
+		evm  *EVM
+		want []common.Address
+	}{
+		{
+			name: "istanbul-plus-quorum-privacy",
+			evm: &EVM{
+				chainRules: params.Rules{
+					IsIstanbul:          true,
+					IsPrivacyPrecompile: true,
+				},
+			},
+			want: []common.Address{
+				common.BytesToAddress([]byte{1}),
+				common.BytesToAddress([]byte{2}),
+				common.BytesToAddress([]byte{3}),
+				common.BytesToAddress([]byte{4}),
+				common.BytesToAddress([]byte{5}),
+				common.BytesToAddress([]byte{6}),
+				common.BytesToAddress([]byte{7}),
+				common.BytesToAddress([]byte{8}),
+				common.BytesToAddress([]byte{9}),
+				common.QuorumPrivacyPrecompileContractAddress(),
+			},
+		},
+		{
+			name: "homestead-plus-quorum-privacy",
+			evm: &EVM{
+				chainRules: params.Rules{
+					IsHomestead:         true,
+					IsPrivacyPrecompile: true,
+				},
+			},
+			want: []common.Address{
+				common.BytesToAddress([]byte{1}),
+				common.BytesToAddress([]byte{2}),
+				common.BytesToAddress([]byte{3}),
+				common.BytesToAddress([]byte{4}),
+				common.QuorumPrivacyPrecompileContractAddress(),
+			},
+		},
+		{
+			name: "istanbul",
+			evm: &EVM{
+				chainRules: params.Rules{
+					IsIstanbul:          true,
+					IsPrivacyPrecompile: false,
+				},
+			},
+			want: []common.Address{
+				common.BytesToAddress([]byte{1}),
+				common.BytesToAddress([]byte{2}),
+				common.BytesToAddress([]byte{3}),
+				common.BytesToAddress([]byte{4}),
+				common.BytesToAddress([]byte{5}),
+				common.BytesToAddress([]byte{6}),
+				common.BytesToAddress([]byte{7}),
+				common.BytesToAddress([]byte{8}),
+				common.BytesToAddress([]byte{9}),
+			},
+		},
+		{
+			name: "homestead",
+			evm: &EVM{
+				chainRules: params.Rules{
+					IsHomestead:         true,
+					IsPrivacyPrecompile: false,
+				},
+			},
+			want: []common.Address{
+				common.BytesToAddress([]byte{1}),
+				common.BytesToAddress([]byte{2}),
+				common.BytesToAddress([]byte{3}),
+				common.BytesToAddress([]byte{4}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.evm.ActivePrecompiles()
+			require.ElementsMatchf(t, tt.want, got, "want: %v, got: %v", tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes relating to recent upstream geth merges.  

* https://github.com/ethereum/go-ethereum/pull/21509
    * The upstream merge introduced `ActivePrecompiles()` however there is a typo causing tests added in this PR to fail.  This bug was fixed in upstream 1.10.2 - the content of that fix has been included in this change.  To simplify future merges the content of the commit has been copied instead of cherry-picking the commit.
    * The Quorum Privacy Precompile address has been added to `ActivePrecompiles()` list. This is currently only used for the experimental YoloV2 EIP 2929 (where all active precompiles for the current block height must be known) so not critical but worth fixing ahead of the concrete release that will be pulled in from a future upstream geth merge.

