### PR TITLE
p2p/nat: skip TestUPNP in non-CI environments if discover fails (#22877)

### DIFF
--- a/p2p/nat/natupnp_test.go
+++ b/p2p/nat/natupnp_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -162,7 +163,11 @@ func TestUPNP_DDWRT(t *testing.T) {
 	// Attempt to discover the fake device.
 	discovered := discoverUPnP()
 	if discovered == nil {
-		t.Fatalf("not discovered")
+		if os.Getenv("CI") != "" {
+			t.Fatalf("not discovered")
+		} else {
+			t.Skipf("UPnP not discovered (known issue, see https://github.com/ethereum/go-ethereum/issues/21476)")
+		}
 	}
 	upnp, _ := discovered.(*upnp)
 	if upnp.service != "IGDv1-IP1" {


### PR DESCRIPTION
Fixes #1338

https://github.com/ethereum/go-ethereum/issues/21476
https://github.com/ethereum/go-ethereum/pull/22877


