### PR TITLE
Add new genesis config attribut "ibft" and "qbft"

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -272,7 +272,7 @@ func quorumValidateEthService(stack *node.Node, isRaft bool) {
 
 // quorumValidateConsensus checks if a consensus was used. The node is killed if consensus was not used
 func quorumValidateConsensus(ethereum *eth.Ethereum, isRaft bool) {
-	if !isRaft && ethereum.BlockChain().Config().Istanbul == nil && ethereum.BlockChain().Config().Clique == nil {
+	if !isRaft && ethereum.BlockChain().Config().Istanbul == nil && ethereum.BlockChain().Config().IBFT == nil && ethereum.BlockChain().Config().QBFT == nil && ethereum.BlockChain().Config().Clique == nil {
 		utils.Fatalf("Consensus not specified. Exiting!!")
 	}
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1683,11 +1683,11 @@ func setAuthorizationList(ctx *cli.Context, cfg *eth.Config) {
 // Quorum
 func setIstanbul(ctx *cli.Context, cfg *eth.Config) {
 	if ctx.GlobalIsSet(IstanbulRequestTimeoutFlag.Name) {
-		log.Warn("The flag --istanbul.requesttimeout is deprecated and will be removed in the future, please use ibft.requesttimeoutseconds on genesis file")
+		log.Warn("WARNING: The flag --istanbul.requesttimeout is deprecated and will be removed in the future, please use ibft.requesttimeoutseconds on genesis file")
 		cfg.Istanbul.RequestTimeout = ctx.GlobalUint64(IstanbulRequestTimeoutFlag.Name)
 	}
 	if ctx.GlobalIsSet(IstanbulBlockPeriodFlag.Name) {
-		log.Warn("The flag --istanbul.blockperiod is deprecated and will be removed in the future, please use ibft.blockperiodseconds on genesis file")
+		log.Warn("WARNING: The flag --istanbul.blockperiod is deprecated and will be removed in the future, please use ibft.blockperiodseconds on genesis file")
 		cfg.Istanbul.BlockPeriod = ctx.GlobalUint64(IstanbulBlockPeriodFlag.Name)
 	}
 }
@@ -2236,14 +2236,12 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readOnly bool, useExist bool)
 	} else if config.IBFT != nil {
 		consensusCount++
 		ibftConfig := setBFTConfig(config.IBFT.BFTConfig)
-		//TODO: @achraf to remove
-		log.Debug("AAAAAAAAAAAAAAAA IBFT", "ibftConfig", ibftConfig)
+		ibftConfig.TestQBFTBlock = nil
 		engine = istanbulBackend.New(ibftConfig, stack.GetNodeKey(), chainDb)
 	} else if config.QBFT != nil {
 		consensusCount++
 		qbftConfig := setBFTConfig(config.QBFT.BFTConfig)
-		// TODO: @achraf to remove
-		log.Debug("AAAAAAAAAAAAAAAA QBFT", "qbftConfig", qbftConfig)
+		qbftConfig.TestQBFTBlock = big.NewInt(0)
 		engine = istanbulBackend.New(qbftConfig, stack.GetNodeKey(), chainDb)
 	} else if config.IsQuorum {
 		// for Raft

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2210,13 +2210,10 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readOnly bool, useExist bool)
 		}
 	}
 
-	consensusCount := uint8(0)
 	var engine consensus.Engine
 	if config.Clique != nil {
-		consensusCount++
 		engine = clique.New(config.Clique, chainDb)
 	} else if config.Istanbul != nil {
-		consensusCount++
 		log.Warn("WARNING: The attribute config.istanbul is deprecated and will be removed in the future, please use config.ibft on genesis file")
 		// for IBFT
 		istanbulConfig := istanbul.DefaultConfig
@@ -2228,12 +2225,10 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readOnly bool, useExist bool)
 		istanbulConfig.TestQBFTBlock = config.Istanbul.TestQBFTBlock
 		engine = istanbulBackend.New(istanbulConfig, stack.GetNodeKey(), chainDb)
 	} else if config.IBFT != nil {
-		consensusCount++
 		ibftConfig := setBFTConfig(config.IBFT.BFTConfig)
 		ibftConfig.TestQBFTBlock = nil
 		engine = istanbulBackend.New(ibftConfig, stack.GetNodeKey(), chainDb)
 	} else if config.QBFT != nil {
-		consensusCount++
 		qbftConfig := setBFTConfig(config.QBFT.BFTConfig)
 		qbftConfig.TestQBFTBlock = big.NewInt(0)
 		engine = istanbulBackend.New(qbftConfig, stack.GetNodeKey(), chainDb)
@@ -2254,9 +2249,6 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readOnly bool, useExist bool)
 				DatasetsLockMmap: ethconfig.Defaults.Ethash.DatasetsLockMmap,
 			}, nil, false)
 		}
-	}
-	if consensusCount > 1 {
-		Fatalf("Too many consensus algorithms specified please review genesis.json")
 	}
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -150,6 +150,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		if config.QuorumChainConfig.PrivacyMarkerEnabled() && chainConfig.PrivacyPrecompileBlock == nil {
 			return nil, errors.New("Privacy marker transactions require privacyPrecompileBlock to be set in genesis.json")
 		}
+		if chainConfig.Istanbul != nil && (chainConfig.IBFT != nil || chainConfig.QBFT != nil) {
+			return nil, errors.New("the attributes config.Istanbul and config.[IBFT|QBFT] are mutually exclusive on the genesis file")
+		}
+		if chainConfig.IBFT != nil && chainConfig.QBFT != nil {
+			return nil, errors.New("the attributes config.IBFT and config.QBFT are mutually exclusive on the genesis file")
+		}
 	}
 
 	if !rawdb.GetIsQuorumEIP155Activated(chainDb) && chainConfig.ChainID != nil {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -233,6 +233,7 @@ func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, co
 	}
 	// If Istanbul is requested, set it up
 	if chainConfig.Istanbul != nil {
+		log.Warn("WARNING: The attribute config.istanbul is deprecated and will be removed in the future, please use config.ibft on genesis file")
 		if chainConfig.Istanbul.Epoch != 0 {
 			config.Istanbul.Epoch = chainConfig.Istanbul.Epoch
 		}
@@ -241,6 +242,16 @@ func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, co
 		config.Istanbul.AllowedFutureBlockTime = config.Miner.AllowedFutureBlockTime //Quorum
 		config.Istanbul.TestQBFTBlock = chainConfig.Istanbul.TestQBFTBlock
 
+		return istanbulBackend.New(&config.Istanbul, stack.GetNodeKey(), db)
+	}
+	if chainConfig.IBFT != nil {
+		setBFTConfig(&config.Istanbul, chainConfig.IBFT.BFTConfig)
+		config.Istanbul.TestQBFTBlock = nil
+		return istanbulBackend.New(&config.Istanbul, stack.GetNodeKey(), db)
+	}
+	if chainConfig.QBFT != nil {
+		setBFTConfig(&config.Istanbul, chainConfig.QBFT.BFTConfig)
+		config.Istanbul.TestQBFTBlock = big.NewInt(0)
 		return istanbulBackend.New(&config.Istanbul, stack.GetNodeKey(), db)
 	}
 	// Otherwise assume proof-of-work
@@ -260,5 +271,23 @@ func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, co
 		// use the consensus with the lightest overhead
 		log.Warn("Ethash used in full fake mode")
 		return ethash.NewFullFaker()
+	}
+}
+
+func setBFTConfig(istanbulConfig *istanbul.Config, bftConfig *params.BFTConfig) {
+	if bftConfig.BlockPeriodSeconds != 0 {
+		istanbulConfig.BlockPeriod = bftConfig.BlockPeriodSeconds
+	}
+	if bftConfig.RequestTimeoutSeconds != 0 {
+		istanbulConfig.RequestTimeout = bftConfig.RequestTimeoutSeconds
+	}
+	if bftConfig.EpochLength != 0 {
+		istanbulConfig.Epoch = bftConfig.EpochLength
+	}
+	if bftConfig.ProposerPolicy != 0 {
+		istanbulConfig.ProposerPolicy = istanbul.NewProposerPolicy(istanbul.ProposerPolicyId(bftConfig.ProposerPolicy))
+	}
+	if bftConfig.Ceil2Nby3Block != nil {
+		istanbulConfig.Ceil2Nby3Block = bftConfig.Ceil2Nby3Block
 	}
 }

--- a/eth/ethconfig/config_test.go
+++ b/eth/ethconfig/config_test.go
@@ -1,0 +1,24 @@
+package ethconfig
+
+import (
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+)
+
+func TestSetBFT(t *testing.T) {
+	config := istanbul.DefaultConfig
+	bftConfig := &params.BFTConfig{
+		EpochLength:           10000,
+		Ceil2Nby3Block:        big.NewInt(10),
+		RequestTimeoutSeconds: 100,
+	}
+	setBFTConfig(config, bftConfig)
+	assert.Equal(t, config.Ceil2Nby3Block, bftConfig.Ceil2Nby3Block)
+	assert.Equal(t, config.Epoch, bftConfig.EpochLength)
+	assert.Equal(t, config.RequestTimeout, bftConfig.RequestTimeoutSeconds)
+	assert.Equal(t, config.BlockPeriod, istanbul.DefaultConfig.BlockPeriod)
+	assert.Equal(t, config.ProposerPolicy, istanbul.DefaultConfig.ProposerPolicy)
+}

--- a/eth/ethconfig/config_test.go
+++ b/eth/ethconfig/config_test.go
@@ -1,11 +1,12 @@
 package ethconfig
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
-	"math/big"
-	"testing"
 )
 
 func TestSetBFT(t *testing.T) {

--- a/params/config.go
+++ b/params/config.go
@@ -241,21 +241,21 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil, nil, false, 32, 35, big.NewInt(0), big.NewInt(0), nil, nil, false, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil, nil, nil, nil, false, 32, 35, big.NewInt(0), big.NewInt(0), nil, nil, false, nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, false, 32, 32, big.NewInt(0), big.NewInt(0), nil, nil, false, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil, nil, nil, false, 32, 32, big.NewInt(0), big.NewInt(0), nil, nil, false, nil}
 
 	// Quorum chainID should 10
-	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil, nil, false, 32, 32, big.NewInt(0), big.NewInt(0), nil, nil, false, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, new(EthashConfig), nil, nil, nil, nil, false, 32, 32, big.NewInt(0), big.NewInt(0), nil, nil, false, nil}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 
-	QuorumTestChainConfig    = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64, 32, big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), false, nil}
-	QuorumMPSTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, new(EthashConfig), nil, nil, true, 64, 32, big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), true, nil}
+	QuorumTestChainConfig    = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, new(EthashConfig), nil, nil, nil, nil, true, 64, 32, big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), false, nil}
+	QuorumMPSTestChainConfig = &ChainConfig{big.NewInt(10), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, new(EthashConfig), nil, nil, nil, nil, true, 64, 32, big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), true, nil}
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and
@@ -339,6 +339,8 @@ type ChainConfig struct {
 	Ethash   *EthashConfig   `json:"ethash,omitempty"`
 	Clique   *CliqueConfig   `json:"clique,omitempty"`
 	Istanbul *IstanbulConfig `json:"istanbul,omitempty"` // Quorum
+	IBFT     *IBFTConfig     `json:"ibft,omitempty"`     // Quorum
+	QBFT     *QBFTConfig     `json:"qbft,omitempty"`     // Quorum
 
 	// Start of Quorum specific configs
 
@@ -390,6 +392,30 @@ type IstanbulConfig struct {
 // String implements the stringer interface, returning the consensus engine details.
 func (c *IstanbulConfig) String() string {
 	return "istanbul"
+}
+
+type BFTConfig struct {
+	EpochLength           uint64   `json:"epochlength"`              // Number of blocks that should pass before pending validator votes are reset
+	BlockPeriodSeconds    uint64   `json:"blockperiodseconds"`       // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
+	RequestTimeoutSeconds uint64   `json:"requesttimeoutseconds"`    // Minimum request timeout for each IBFT or QBFT round in milliseconds
+	ProposerPolicy        uint64   `json:"policy"`                   // The policy for proposer selection
+	Ceil2Nby3Block        *big.Int `json:"ceil2Nby3Block,omitempty"` // Number of confirmations required to move from one state to next [2F + 1 to Ceil(2N/3)]
+}
+
+type IBFTConfig struct {
+	*BFTConfig
+}
+
+func (c IBFTConfig) String() string {
+	return "istanbul"
+}
+
+type QBFTConfig struct {
+	*BFTConfig
+}
+
+func (c QBFTConfig) String() string {
+	return "qbft"
 }
 
 // String implements the fmt.Stringer interface.


### PR DESCRIPTION
- Add new attribut in the config of the genesis file
```json
"config": {
  "qbft": {
    "blockperiodseconds": 2,
    "epochlength": 30000,
    "requesttimeoutseconds": 4
  },
  "ibft": {
    "blockperiodseconds": 2,
    "epochlength": 30000,
    "requesttimeoutseconds": 4
  }
}
```
- The `--istanbul.requesttimeout` and `--istanbul.blockperiod` are deprecated