### PR TITLE
Fix signing typed transactions with plugin accounts

### DIFF
--- a/accounts/pluggable/wallet.go
+++ b/accounts/pluggable/wallet.go
@@ -119,10 +119,8 @@ func prepareTxForSign(tx *types.Transaction, chainID *big.Int) (common.Hash, typ
 
 	if tx.IsPrivate() {
 		s = types.QuorumPrivateTxSigner{}
-	} else if chainID == nil {
-		s = types.HomesteadSigner{}
 	} else {
-		s = types.NewEIP155Signer(chainID)
+		s = types.LatestSignerForChainID(chainID)
 	}
 
 	return s.Hash(tx), s

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -428,6 +428,7 @@ func startNode(ctx *cli.Context, stack *node.Node, backend ethapi.Backend) {
 		if err := stack.PluginManager().AddAccountPluginToBackend(b); err != nil {
 			log.Error("failed to setup account plugin", "err", err)
 		}
+		log.Info("registered account plugin with account backend")
 	}
 
 	// Unlock any account specifically requested


### PR DESCRIPTION
Support [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)/berlin fork typed txs (the only type introduced so far is [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)) when using account plugins.

This fixes the following error when trying to send an EIP-2930 transaction from a plugin account:
```
> eth.sendTransaction({from: sender, to: recipient, data:d, accessList:[{address: "0x9186eb3d20cbd1f5f992a950d808c4495153abd5",storageKeys:[]}]})
Error: transaction type not supported
	at web3.js:6355:37(47)
	at web3.js:5089:62(37)
	at <eval>:1:20(17)
```

This is a low impact fix as EIP-2930 txs are unlikely to be used as their purpose is to provide gas cost discounts.  However it is important for plugin accounts to be able to send new tx types as they are added.