### PR TITLE
Fix potential goroutine leak in istanbul backend_test

### DIFF
--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -119,7 +119,6 @@ func TestCommit(t *testing.T) {
 	backend := newBackend()
 	defer backend.Stop()
 
-	commitCh := make(chan *types.Block)
 	// Case: it's a proposer, so the backend.commit will receive channel result from backend.Commit function
 	testCases := []struct {
 		expectedErr       error
@@ -147,6 +146,7 @@ func TestCommit(t *testing.T) {
 			},
 		},
 	}
+	commitCh := make(chan *types.Block, len(testCases))
 
 	for _, test := range testCases {
 		expBlock := test.expectedBlock()
@@ -192,7 +192,7 @@ func TestGetProposer(t *testing.T) {
 // This was fixed as part of commit 2a8310663ecafc0233758ca7883676bf568e926e
 func TestQBFTTransitionDeadlock(t *testing.T) {
 	timeout := time.After(1 * time.Minute)
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	go func() {
 		chain, engine := newBlockChain(1, big.NewInt(1))
 		defer engine.Stop()


### PR DESCRIPTION
1. In func `TestQBFTTransitionDeadlock`,
Goroutine may leak because sending to chan doneis blocked forever on [L195](https://github.com/ConsenSys/quorum/blob/c11973341c37354845d61729eb7165ad8a241593/consensus/istanbul/backend/backend_test.go#L195) when select selects `timeout` on [L217](https://github.com/ConsenSys/quorum/blob/c11973341c37354845d61729eb7165ad8a241593/consensus/istanbul/backend/backend_test.go#L217). Although `t.Fatal()` is called in this case, it won't stop the leaking, because  because "[Calling FailNow does not stop those other goroutines.](https://golang.org/pkg/testing/#T.FailNow)".The fix is to replace the unbuffered channel with a buffered channel (buffer size 1), and the semantic is not changed.  
2. Similarly, in func `TestCommit`, 
sending to chan commitChis blocked  forever on [L122](https://github.com/ConsenSys/quorum/blob/c11973341c37354845d61729eb7165ad8a241593/consensus/istanbul/backend/backend_test.go#L122) when selectselects time.Afteron [L172](https://github.com/ConsenSys/quorum/blob/c11973341c37354845d61729eb7165ad8a241593/consensus/istanbul/backend/backend_test.go#L172). The buffer size equals to the num of testCases.