### PR TITLE
Fix potential goroutine leak in rawdb/freezer_test

### DIFF
--- a/core/rawdb/freezer_test.go
+++ b/core/rawdb/freezer_test.go
@@ -18,7 +18,7 @@ func Test_freezer_Close(t *testing.T) {
 
 	// Close second time should return error but do not hang sending data to freeze.quit channel
 	timeout := time.After(1 * time.Second)
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 
 	go func() {
 		errCh <- mockFreezer.Close()


### PR DESCRIPTION
In func `Test_freezer_Close`,
Goroutine may leak because sending to chan errChis blocked forever on [L21](https://github.com/ConsenSys/quorum/blob/c11973341c37354845d61729eb7165ad8a241593/core/rawdb/freezer_test.go#L21) when select selects `timeout` on [L28](https://github.com/ConsenSys/quorum/blob/c11973341c37354845d61729eb7165ad8a241593/core/rawdb/freezer_test.go#L28). Although `t.Fatal()` is called in this case, it won't stop the leaking, because  because "[Calling FailNow does not stop those other goroutines.](https://golang.org/pkg/testing/#T.FailNow)". The fix is to replace the unbuffered channel with a buffered channel (buffer size 1), and the semantic is not changed.