### PR TITLE
qbft: add new block period setting used when the block is empty

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2603,6 +2603,12 @@ func setBFTConfig(bftConfig *params.BFTConfig) *istanbul.Config {
 	if bftConfig.BlockPeriodSeconds != 0 {
 		istanbulConfig.BlockPeriod = bftConfig.BlockPeriodSeconds
 	}
+	if bftConfig.EmptyBlockPeriodSeconds != 0 {
+		istanbulConfig.EmptyBlockPeriod = bftConfig.EmptyBlockPeriodSeconds
+	}
+	if istanbulConfig.EmptyBlockPeriod < istanbulConfig.BlockPeriod {
+		istanbulConfig.EmptyBlockPeriod = istanbulConfig.BlockPeriod
+	}
 	if bftConfig.RequestTimeoutSeconds != 0 {
 		istanbulConfig.RequestTimeout = bftConfig.RequestTimeoutSeconds * 1000
 	}

--- a/cmd/utils/flags_test.go
+++ b/cmd/utils/flags_test.go
@@ -204,5 +204,6 @@ func TestQuorumConfigFlags(t *testing.T) {
 	config := arbitraryEthConfig.Istanbul.GetConfig(nil)
 	assert.Equal(t, uint64(23), config.RequestTimeout, "IstanbulRequestTimeoutFlag value is incorrect")
 	assert.Equal(t, uint64(34), config.BlockPeriod, "IstanbulBlockPeriodFlag value is incorrect")
+	assert.Equal(t, uint64(34), config.EmptyBlockPeriod, "IstanbulEmptyBlockPeriodFlag value is incorrect")
 	assert.Equal(t, true, arbitraryEthConfig.RaftMode, "RaftModeFlag value is incorrect")
 }

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -123,6 +123,7 @@ func (p *ProposerPolicy) ClearRegistry() {
 type Config struct {
 	RequestTimeout         uint64          `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
 	BlockPeriod            uint64          `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
+	EmptyBlockPeriod       uint64          `toml:",omitempty"` // Default minimum difference between a block and empty block's timestamps in second
 	ProposerPolicy         *ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
 	Epoch                  uint64          `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
 	Ceil2Nby3Block         *big.Int        `toml:",omitempty"` // Number of confirmations required to move from one state to next [2F + 1 to Ceil(2N/3)]
@@ -136,6 +137,7 @@ type Config struct {
 var DefaultConfig = &Config{
 	RequestTimeout:         10000,
 	BlockPeriod:            1,
+	EmptyBlockPeriod:       10,
 	ProposerPolicy:         NewRoundRobinProposerPolicy(),
 	Epoch:                  30000,
 	Ceil2Nby3Block:         big.NewInt(0),
@@ -182,6 +184,12 @@ func (c Config) GetConfig(blockNumber *big.Int) Config {
 		if c.Transitions[i].BlockPeriodSeconds != 0 {
 			newConfig.BlockPeriod = c.Transitions[i].BlockPeriodSeconds
 		}
+		if c.Transitions[i].EmptyBlockPeriodSeconds != 0 {
+			newConfig.EmptyBlockPeriod = c.Transitions[i].EmptyBlockPeriodSeconds
+		}
+	}
+	if newConfig.EmptyBlockPeriod < newConfig.BlockPeriod {
+		newConfig.EmptyBlockPeriod = newConfig.BlockPeriod
 	}
 	return newConfig
 }

--- a/consensus/istanbul/config_test.go
+++ b/consensus/istanbul/config_test.go
@@ -60,14 +60,19 @@ func TestGetConfig(t *testing.T) {
 		Block:              big.NewInt(3),
 		BlockPeriodSeconds: 5,
 	}, {
-		Block:                 big.NewInt(5),
-		RequestTimeoutSeconds: 15000,
+		Block:                   big.NewInt(5),
+		RequestTimeoutSeconds:   15000,
+		EmptyBlockPeriodSeconds: 1,
 	}}
 	config1 := *DefaultConfig
 	config1.Epoch = 40000
+	config1.BlockPeriod = 1       // default value
+	config1.EmptyBlockPeriod = 10 // default value
 	config3 := config1
 	config3.BlockPeriod = 5
+	config3.EmptyBlockPeriod = 10
 	config5 := config3
+	config5.EmptyBlockPeriod = 5 // equals to block period because it can be lower than this active value (5) from block 3
 	config5.RequestTimeout = 15000
 
 	type test struct {

--- a/consensus/istanbul/qbft/core/core.go
+++ b/consensus/istanbul/qbft/core/core.go
@@ -90,6 +90,9 @@ type core struct {
 	pendingRequestsMu *sync.Mutex
 
 	consensusTimestamp time.Time
+
+	newRoundMutex sync.Mutex
+	newRoundTimer *time.Timer
 }
 
 func (c *core) currentView() *istanbul.View {
@@ -250,6 +253,10 @@ func (c *core) stopTimer() {
 
 func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
+
+	for c.current == nil { // wait because it is asynchronous in handleRequest
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	// set timeout based on the round number
 	baseTimeout := time.Duration(c.config.GetConfig(c.current.Sequence()).RequestTimeout) * time.Millisecond

--- a/consensus/istanbul/qbft/core/request.go
+++ b/consensus/istanbul/qbft/core/request.go
@@ -58,7 +58,7 @@ func (c *core) handleRequest(request *Request) error {
 		block, ok := request.Proposal.(*types.Block)
 		if ok && len(block.Transactions()) == 0 { // if empty block
 			config := c.config.GetConfig(c.current.Sequence())
-			delay = -time.Since(time.Unix(int64(block.Time()), 0)) + time.Duration(config.EmptyBlockPeriod-config.BlockPeriod)*time.Second
+			delay = time.Duration(config.EmptyBlockPeriod-config.BlockPeriod) * time.Second
 		}
 
 		c.newRoundTimer = time.AfterFunc(delay, func() {

--- a/consensus/istanbul/qbft/core/request.go
+++ b/consensus/istanbul/qbft/core/request.go
@@ -57,7 +57,7 @@ func (c *core) handleRequest(request *Request) error {
 
 		block, ok := request.Proposal.(*types.Block)
 		if ok && len(block.Transactions()) == 0 { // if empty block
-			delay = time.Duration(c.config.EmptyBlockPeriod-c.config.BlockPeriod) * time.Second
+			delay = -time.Since(time.Unix(int64(block.Time()), 0)) + time.Duration(c.config.EmptyBlockPeriod-c.config.BlockPeriod)*time.Second
 		}
 
 		c.newRoundTimer = time.AfterFunc(delay, func() {

--- a/consensus/istanbul/qbft/core/request.go
+++ b/consensus/istanbul/qbft/core/request.go
@@ -17,7 +17,10 @@
 package core
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // handleRequest is called by proposer in reaction to `miner.Seal()`
@@ -42,11 +45,30 @@ func (c *core) handleRequest(request *Request) error {
 
 	c.current.pendingRequest = request
 	if c.state == StateAcceptRequest {
-		// Start ROUND-CHANGE timer
-		c.newRoundChangeTimer()
+		c.newRoundMutex.Lock()
+		defer c.newRoundMutex.Unlock()
 
-		// Send PRE-PREPARE message to other validators
-		c.sendPreprepareMsg(request)
+		if c.newRoundTimer != nil {
+			c.newRoundTimer.Stop()
+			c.newRoundTimer = nil
+		}
+
+		delay := time.Duration(0)
+
+		block, ok := request.Proposal.(*types.Block)
+		if ok && len(block.Transactions()) == 0 { // if empty block
+			delay = time.Duration(c.config.EmptyBlockPeriod-c.config.BlockPeriod) * time.Second
+		}
+
+		c.newRoundTimer = time.AfterFunc(delay, func() {
+			c.newRoundTimer = nil
+
+			// Start ROUND-CHANGE timer
+			c.newRoundChangeTimer()
+
+			// Send PRE-PREPARE message to other validators
+			c.sendPreprepareMsg(request)
+		})
 	}
 
 	return nil

--- a/consensus/istanbul/qbft/core/request.go
+++ b/consensus/istanbul/qbft/core/request.go
@@ -57,7 +57,8 @@ func (c *core) handleRequest(request *Request) error {
 
 		block, ok := request.Proposal.(*types.Block)
 		if ok && len(block.Transactions()) == 0 { // if empty block
-			delay = -time.Since(time.Unix(int64(block.Time()), 0)) + time.Duration(c.config.EmptyBlockPeriod-c.config.BlockPeriod)*time.Second
+			config := c.config.GetConfig(c.current.Sequence())
+			delay = -time.Since(time.Unix(int64(block.Time()), 0)) + time.Duration(config.EmptyBlockPeriod-config.BlockPeriod)*time.Second
 		}
 
 		c.newRoundTimer = time.AfterFunc(delay, func() {

--- a/consensus/istanbul/qbft/engine/engine.go
+++ b/consensus/istanbul/qbft/engine/engine.go
@@ -101,10 +101,11 @@ func (e *Engine) VerifyBlockProposal(chain consensus.ChainHeaderReader, block *t
 		return time.Until(time.Unix(int64(block.Header().Time), 0)), consensus.ErrFutureBlock
 	}
 
-	if e.cfg.EmptyBlockPeriod > e.cfg.BlockPeriod && len(block.Transactions()) == 0 {
+	config := e.cfg.GetConfig(block.Number())
+	if config.EmptyBlockPeriod > config.BlockPeriod && len(block.Transactions()) == 0 {
 		// empty block verification
 		parentHeader := chain.GetHeaderByHash(block.ParentHash())
-		if parentHeader != nil && block.Header().Time < parentHeader.Time+e.cfg.EmptyBlockPeriod {
+		if parentHeader != nil && block.Header().Time < parentHeader.Time+config.EmptyBlockPeriod {
 			return 0, fmt.Errorf("empty block verification fail")
 		}
 	}

--- a/consensus/istanbul/qbft/engine/engine.go
+++ b/consensus/istanbul/qbft/engine/engine.go
@@ -328,7 +328,7 @@ func (e *Engine) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 	header.Difficulty = istanbulcommon.DefaultDifficulty
 
 	// set header's timestamp
-	header.Time = parent.Time + e.cfg.GetConfig(header.Number).BlockPeriod // TODO use block period is block is not empty
+	header.Time = parent.Time + e.cfg.GetConfig(header.Number).BlockPeriod
 	if header.Time < uint64(time.Now().Unix()) {
 		header.Time = uint64(time.Now().Unix())
 	}

--- a/consensus/istanbul/qbft/engine/engine.go
+++ b/consensus/istanbul/qbft/engine/engine.go
@@ -95,7 +95,7 @@ func (e *Engine) VerifyBlockProposal(chain consensus.ChainHeaderReader, block *t
 	if len(block.Transactions()) == 0 {
 		// empty block verification
 		parentHeader := chain.GetHeaderByHash(block.ParentHash())
-		if parentHeader != nil && block.Header().Time >= parentHeader.Time+uint64(e.cfg.EmptyBlockPeriod-e.cfg.BlockPeriod) {
+		if parentHeader != nil && block.Header().Time >= parentHeader.Time+e.cfg.EmptyBlockPeriod-e.cfg.BlockPeriod {
 			return time.Until(time.Unix(int64(block.Header().Time), 0)), fmt.Errorf("empty block verification fail")
 		}
 	}
@@ -127,9 +127,6 @@ func (e *Engine) verifyHeader(chain consensus.ChainHeaderReader, header *types.H
 
 	// Don't waste time checking blocks from the future (adjusting for allowed threshold)
 	adjustedTimeNow := time.Now().Add(time.Duration(e.cfg.AllowedFutureBlockTime) * time.Second).Unix()
-	/*if emptyBlock {
-		adjustedTimeNow = adjustedTimeNow + int64(e.cfg.EmptyBlockPeriod-e.cfg.BlockPeriod)
-	}*/
 	if header.Time > uint64(adjustedTimeNow) {
 		return consensus.ErrFutureBlock
 	}
@@ -395,15 +392,6 @@ func (e *Engine) Seal(chain consensus.ChainHeaderReader, block *types.Block, val
 
 	// Set Coinbase
 	header.Coinbase = e.signer
-
-	/*if len(block.Transactions()) > 0 {
-		header.Time += e.cfg.BlockPeriod - e.cfg.EmptyBlockPeriod // use block period
-	}*/
-	/*if len(block.Transactions()) == 0 {
-		next := header.Time + e.cfg.EmptyBlockPeriod - e.cfg.BlockPeriod
-		log.Debug("empty block", "next", next)
-		time.Sleep(time.Duration(int64(next)-time.Now().Unix()) * time.Second)
-	}*/
 
 	return block.WithSeal(header), nil
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -299,6 +299,12 @@ func setBFTConfig(istanbulConfig *istanbul.Config, bftConfig *params.BFTConfig) 
 	if bftConfig.BlockPeriodSeconds != 0 {
 		istanbulConfig.BlockPeriod = bftConfig.BlockPeriodSeconds
 	}
+	if bftConfig.EmptyBlockPeriodSeconds != 0 {
+		istanbulConfig.EmptyBlockPeriod = bftConfig.EmptyBlockPeriodSeconds
+	}
+	if bftConfig.EmptyBlockPeriodSeconds < bftConfig.BlockPeriodSeconds {
+		istanbulConfig.EmptyBlockPeriod = bftConfig.BlockPeriodSeconds
+	}
 	if bftConfig.RequestTimeoutSeconds != 0 {
 		istanbulConfig.RequestTimeout = bftConfig.RequestTimeoutSeconds * 1000
 	}

--- a/eth/ethconfig/config_test.go
+++ b/eth/ethconfig/config_test.go
@@ -21,5 +21,6 @@ func TestSetBFT(t *testing.T) {
 	assert.Equal(t, config.Epoch, bftConfig.EpochLength)
 	assert.Equal(t, config.RequestTimeout, bftConfig.RequestTimeoutSeconds*1000)
 	assert.Equal(t, config.BlockPeriod, istanbul.DefaultConfig.BlockPeriod)
+	assert.Equal(t, config.EmptyBlockPeriod, istanbul.DefaultConfig.EmptyBlockPeriod)
 	assert.Equal(t, config.ProposerPolicy, istanbul.DefaultConfig.ProposerPolicy)
 }

--- a/eth/ethconfig/config_test.go
+++ b/eth/ethconfig/config_test.go
@@ -23,4 +23,33 @@ func TestSetBFT(t *testing.T) {
 	assert.Equal(t, config.BlockPeriod, istanbul.DefaultConfig.BlockPeriod)
 	assert.Equal(t, config.EmptyBlockPeriod, istanbul.DefaultConfig.EmptyBlockPeriod)
 	assert.Equal(t, config.ProposerPolicy, istanbul.DefaultConfig.ProposerPolicy)
+
+	bftConfig = &params.BFTConfig{
+		EpochLength:             10000,
+		Ceil2Nby3Block:          big.NewInt(10),
+		RequestTimeoutSeconds:   100,
+		EmptyBlockPeriodSeconds: 1, // less than block period is making this disable, will be replace by block period
+		BlockPeriodSeconds:      5,
+	}
+	setBFTConfig(config, bftConfig)
+	assert.Equal(t, config.Ceil2Nby3Block, bftConfig.Ceil2Nby3Block)
+	assert.Equal(t, config.Epoch, bftConfig.EpochLength)
+	assert.Equal(t, config.RequestTimeout, bftConfig.RequestTimeoutSeconds*1000)
+	assert.Equal(t, config.BlockPeriod, uint64(5))
+	assert.Equal(t, config.EmptyBlockPeriod, uint64(5))
+	assert.Equal(t, config.ProposerPolicy, istanbul.DefaultConfig.ProposerPolicy)
+
+	bftConfig = &params.BFTConfig{
+		EpochLength:             10000,
+		Ceil2Nby3Block:          big.NewInt(10),
+		RequestTimeoutSeconds:   100,
+		EmptyBlockPeriodSeconds: 5,
+	}
+	setBFTConfig(config, bftConfig)
+	assert.Equal(t, config.Ceil2Nby3Block, bftConfig.Ceil2Nby3Block)
+	assert.Equal(t, config.Epoch, bftConfig.EpochLength)
+	assert.Equal(t, config.RequestTimeout, bftConfig.RequestTimeoutSeconds*1000)
+	assert.Equal(t, config.BlockPeriod, istanbul.DefaultConfig.BlockPeriod)
+	assert.Equal(t, config.EmptyBlockPeriod, uint64(5))
+	assert.Equal(t, config.ProposerPolicy, istanbul.DefaultConfig.ProposerPolicy)
 }

--- a/params/config.go
+++ b/params/config.go
@@ -403,6 +403,7 @@ func (c *IstanbulConfig) String() string {
 type BFTConfig struct {
 	EpochLength              uint64         `json:"epochlength"`              // Number of blocks that should pass before pending validator votes are reset
 	BlockPeriodSeconds       uint64         `json:"blockperiodseconds"`       // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
+	EmptyBlockPeriodSeconds  uint64         `json:"emptyblockperiodseconds"`  // Minimum time between two consecutive IBFT or QBFT a block and empty block’ timestamps in seconds
 	RequestTimeoutSeconds    uint64         `json:"requesttimeoutseconds"`    // Minimum request timeout for each IBFT or QBFT round in milliseconds
 	ProposerPolicy           uint64         `json:"policy"`                   // The policy for proposer selection
 	Ceil2Nby3Block           *big.Int       `json:"ceil2Nby3Block,omitempty"` // Number of confirmations required to move from one state to next [2F + 1 to Ceil(2N/3)]
@@ -436,12 +437,13 @@ const (
 type Transition struct {
 	Block                    *big.Int       `json:"block"`
 	Algorithm                string         `json:"algorithm,omitempty"`
-	EpochLength              uint64         `json:"epochlength,omitempty"`           // Number of blocks that should pass before pending validator votes are reset
-	BlockPeriodSeconds       uint64         `json:"blockperiodseconds,omitempty"`    // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
-	RequestTimeoutSeconds    uint64         `json:"requesttimeoutseconds,omitempty"` // Minimum request timeout for each IBFT or QBFT round in milliseconds
-	ContractSizeLimit        uint64         `json:"contractsizelimit,omitempty"`     // Maximum smart contract code size
-	ValidatorContractAddress common.Address `json:"validatorcontractaddress"`        // Smart contract address for list of validators
-	ValidatorSelectionMode   string         `json:"validatorselectionmode"`          // Validator selection mode to switch to
+	EpochLength              uint64         `json:"epochlength,omitempty"`             // Number of blocks that should pass before pending validator votes are reset
+	BlockPeriodSeconds       uint64         `json:"blockperiodseconds,omitempty"`      // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
+	EmptyBlockPeriodSeconds  uint64         `json:"emptyblockperiodseconds,omitempty"` // Minimum time between two consecutive IBFT or QBFT a block and empty block’ timestamps in seconds
+	RequestTimeoutSeconds    uint64         `json:"requesttimeoutseconds,omitempty"`   // Minimum request timeout for each IBFT or QBFT round in milliseconds
+	ContractSizeLimit        uint64         `json:"contractsizelimit,omitempty"`       // Maximum smart contract code size
+	ValidatorContractAddress common.Address `json:"validatorcontractaddress"`          // Smart contract address for list of validators
+	ValidatorSelectionMode   string         `json:"validatorselectionmode"`            // Validator selection mode to switch to
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -330,10 +330,10 @@ func TestCheckTransitionsData(t *testing.T) {
 		wantErr error
 	}
 	var ibftTransitionsConfig, qbftTransitionsConfig, invalidTransition, invalidBlockOrder []Transition
-	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 10, 50, common.Address{}, ""}
-	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 50, common.Address{}, ""}
-	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 10, 50, common.Address{}, ""}
-	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 50, common.Address{}, ""}
+	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 10, 10, 50, common.Address{}, ""}
+	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, ""}
+	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 10, 10, 50, common.Address{}, ""}
+	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, ""}
 
 	ibftTransitionsConfig = append(ibftTransitionsConfig, tranI0, tranI10)
 	qbftTransitionsConfig = append(qbftTransitionsConfig, tranQ5, tranQ8)
@@ -393,7 +393,7 @@ func TestCheckTransitionsData(t *testing.T) {
 			wantErr: ErrBlockOrder,
 		},
 		{
-			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 50, common.Address{}, ""}}},
+			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, ""}}},
 			wantErr: ErrBlockNumberMissing,
 		},
 		{


### PR DESCRIPTION
When the mined block is empty, the period will be longer but a new transaction will mine a non-empty block with the block period.

As a result, we mine less frequently empty blocks.