### PR TITLE
remove max parallel from matrix of github actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,7 +116,6 @@ jobs:
     if: success()
     strategy:
       fail-fast: false
-      max-parallel: 6
       matrix:
         # list of tag expression being executed in parallel
         # for PR, only selective tests are run.


### PR DESCRIPTION
remove max parallel as it has no improvement on the execution and avoiding flacky tests.

a matrix task is executed on a vm of 2 VCPU with 6GB RAM, there is no ressource depletion