### PR TITLE
Fix acceptance tests after changes for gas price enabled

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -625,6 +625,14 @@ var (
 // included uncles. The coinbase of each uncle block is also rewarded.
 func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 
+	// Quorum:
+	// Historically, quorum was adding (static) reward to account 0x0.
+	// So need to ensure this is still the case if gas price is not enabled, otherwise reward goes to coinbase.
+	headerCoinbase := header.Coinbase
+	if !config.IsGasPriceEnabled(header.Number) {
+		headerCoinbase = common.Address{0x0000000000000000000000}
+	}
+
 	// Select the correct block reward based on chain progression
 	blockReward := FrontierBlockReward
 	if config.IsByzantium(header.Number) {
@@ -647,7 +655,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 		r.Div(blockReward, big32)
 		reward.Add(reward, r)
 	}
-	state.AddBalance(header.Coinbase, reward)
+	state.AddBalance(headerCoinbase, reward)
 }
 
 // Quorum: wrapper for accumulateRewards to be called by raft minter

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -625,12 +625,6 @@ var (
 // included uncles. The coinbase of each uncle block is also rewarded.
 func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 
-	// Quorum: Disable reward for Quorum if gas price is not enabled,
-	// otherwise static block reward will impact Raft (even though the gas price is zero)
-	if config.IsQuorum && !config.IsGasPriceEnabled(header.Number) {
-		return
-	}
-
 	// Select the correct block reward based on chain progression
 	blockReward := FrontierBlockReward
 	if config.IsByzantium(header.Number) {

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -629,7 +629,7 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 	// Historically, quorum was adding (static) reward to account 0x0.
 	// So need to ensure this is still the case if gas price is not enabled, otherwise reward goes to coinbase.
 	headerCoinbase := header.Coinbase
-	if !config.IsGasPriceEnabled(header.Number) {
+	if config.IsQuorum && !config.IsGasPriceEnabled(header.Number) {
 		headerCoinbase = common.Address{0x0000000000000000000000}
 	}
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1287,7 +1287,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		var drops types.Transactions
-		if !pool.chainconfig.IsQuorum || pool.chainconfig.IsGasPriceEnabled(pool.chain.CurrentBlock().Header().Number) {
+		if !isQuorum || pool.chainconfig.IsGasPriceEnabled(pool.chain.CurrentBlock().Header().Number) {
 			// Drop all transactions that are too costly (low balance or out of gas)
 			drops, _ = list.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas)
 			for _, tx := range drops {


### PR DESCRIPTION
Prior to the changes to enable gas price (PR#1446), Quorum was (incorrectly) rewarding account 0x0 with the static block reward. This behaviour was not carried forward, and if the gas price was not enabled then no reward was given. However, this would cause `BAD BLOCK` errors when upgrading the network and there was a mixture of code versions running. Additionally it was causing the mixed network acceptance tests to fail.

This PR corrects the behaviour and ensures that the reward is still given to account 0x0 if gas price has not been enabled.