### PR TITLE
validation rewards

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2528,6 +2528,8 @@ func MakeChain(ctx *cli.Context, stack *node.Node, useExist bool) (chain *core.B
 		engine = istanbulBackend.New(ibftConfig, stack.GetNodeKey(), chainDb)
 	} else if config.QBFT != nil {
 		qbftConfig := setBFTConfig(config.QBFT.BFTConfig)
+		qbftConfig.BlockReward = config.QBFT.BlockReward
+		qbftConfig.MiningBeneficiary = config.QBFT.MiningBeneficiary
 		qbftConfig.TestQBFTBlock = big.NewInt(0)
 		if config.Transitions != nil && len(config.Transitions) != 0 {
 			qbftConfig.Transitions = config.Transitions

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2531,7 +2531,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, useExist bool) (chain *core.B
 		qbftConfig.BlockReward = config.QBFT.BlockReward
 		qbftConfig.BeneficiaryMode = config.QBFT.BeneficiaryMode     // beneficiary mode: list, besu, validators
 		qbftConfig.BeneficiaryList = config.QBFT.BeneficiaryList     // list mode
-		qbftConfig.MiningBeneficiary = config.QBFT.MiningBeneficiary // besu mode
+		qbftConfig.MiningBeneficiary = config.QBFT.MiningBeneficiary // auto (undefined mode) and besu mode
 		qbftConfig.TestQBFTBlock = big.NewInt(0)
 		if config.Transitions != nil && len(config.Transitions) != 0 {
 			qbftConfig.Transitions = config.Transitions

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2529,7 +2529,9 @@ func MakeChain(ctx *cli.Context, stack *node.Node, useExist bool) (chain *core.B
 	} else if config.QBFT != nil {
 		qbftConfig := setBFTConfig(config.QBFT.BFTConfig)
 		qbftConfig.BlockReward = config.QBFT.BlockReward
-		qbftConfig.MiningBeneficiary = config.QBFT.MiningBeneficiary
+		qbftConfig.BeneficiaryMode = config.QBFT.BeneficiaryMode     // beneficiary mode: list, besu, validators
+		qbftConfig.BeneficiaryList = config.QBFT.BeneficiaryList     // list mode
+		qbftConfig.MiningBeneficiary = config.QBFT.MiningBeneficiary // besu mode
 		qbftConfig.TestQBFTBlock = big.NewInt(0)
 		if config.Transitions != nil && len(config.Transitions) != 0 {
 			qbftConfig.Transitions = config.Transitions

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -123,6 +123,7 @@ func (p *ProposerPolicy) ClearRegistry() {
 
 type Config struct {
 	RequestTimeout         uint64          `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
+	BlockReward            *big.Int        `toml:",omitempty"` // Reward
 	BlockPeriod            uint64          `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
 	EmptyBlockPeriod       uint64          `toml:",omitempty"` // Default minimum difference between a block and empty block's timestamps in second
 	ProposerPolicy         *ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
@@ -130,6 +131,7 @@ type Config struct {
 	Ceil2Nby3Block         *big.Int        `toml:",omitempty"` // Number of confirmations required to move from one state to next [2F + 1 to Ceil(2N/3)]
 	AllowedFutureBlockTime uint64          `toml:",omitempty"` // Max time (in seconds) from current time allowed for blocks, before they're considered future blocks
 	TestQBFTBlock          *big.Int        `toml:",omitempty"` // Fork block at which block confirmations are done using qbft consensus instead of ibft
+	MiningBeneficiary      common.Address  `toml:",omitempty"` // Wallet address of the mining beneficiary
 	Transitions            []params.Transition
 	ValidatorContract      common.Address
 	Client                 bind.ContractCaller `toml:",omitempty"`
@@ -195,6 +197,12 @@ func (c Config) GetConfig(blockNumber *big.Int) Config {
 		}
 		if transition.EmptyBlockPeriodSeconds != 0 {
 			newConfig.EmptyBlockPeriod = transition.EmptyBlockPeriodSeconds
+		}
+		if transition.BlockReward != nil {
+			newConfig.BlockReward = transition.BlockReward
+		}
+		if (transition.MiningBeneficiary != common.Address{}) {
+			newConfig.MiningBeneficiary = transition.MiningBeneficiary
 		}
 	})
 	if newConfig.EmptyBlockPeriod < newConfig.BlockPeriod {

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -131,7 +131,7 @@ type Config struct {
 	Ceil2Nby3Block         *big.Int        `toml:",omitempty"` // Number of confirmations required to move from one state to next [2F + 1 to Ceil(2N/3)]
 	AllowedFutureBlockTime uint64          `toml:",omitempty"` // Max time (in seconds) from current time allowed for blocks, before they're considered future blocks
 	TestQBFTBlock          *big.Int        `toml:",omitempty"` // Fork block at which block confirmations are done using qbft consensus instead of ibft
-	MiningBeneficiary      common.Address  `toml:",omitempty"` // Wallet address of the mining beneficiary
+	MiningBeneficiary      *common.Address `toml:",omitempty"` // Wallet address of the mining beneficiary
 	Transitions            []params.Transition
 	ValidatorContract      common.Address
 	Client                 bind.ContractCaller `toml:",omitempty"`
@@ -201,7 +201,7 @@ func (c Config) GetConfig(blockNumber *big.Int) Config {
 		if transition.BlockReward != nil {
 			newConfig.BlockReward = transition.BlockReward
 		}
-		if (transition.MiningBeneficiary != common.Address{}) {
+		if transition.MiningBeneficiary != nil {
 			newConfig.MiningBeneficiary = transition.MiningBeneficiary
 		}
 	})

--- a/consensus/istanbul/qbft/engine/engine.go
+++ b/consensus/istanbul/qbft/engine/engine.go
@@ -614,6 +614,11 @@ func (e *Engine) accumulateRewards(chain consensus.ChainHeaderReader, state *sta
 			log.Warn("in validators mode, the list of signers should not be empty in order to add block reward to all validators")
 		}
 	default:
-		log.Warn("beneficiary mode not known", "mode", *cfg.BeneficiaryMode)
+		if cfg.MiningBeneficiary != nil {
+			state.AddBalance(*cfg.MiningBeneficiary, &reward)
+			log.Info("beneficiary mode not set but using besu as default because mining beneficiary is set")
+		} else {
+			log.Warn("beneficiary mode not known", "mode", *cfg.BeneficiaryMode)
+		}
 	}
 }

--- a/consensus/istanbul/qbft/engine/engine.go
+++ b/consensus/istanbul/qbft/engine/engine.go
@@ -582,7 +582,7 @@ func (e *Engine) accumulateRewards(chain consensus.ChainHeaderReader, state *sta
 		return
 	}
 	switch strings.ToLower(*cfg.BeneficiaryMode) {
-	case "besu":
+	case "fixed":
 		if cfg.MiningBeneficiary != nil {
 			state.AddBalance(*cfg.MiningBeneficiary, &reward)
 		}

--- a/consensus/istanbul/qbft/engine/engine.go
+++ b/consensus/istanbul/qbft/engine/engine.go
@@ -552,7 +552,7 @@ func (e *Engine) validatorsList(genesis *types.Header, config istanbul.Config) (
 		}
 		validators, err = validatorContractCaller.GetValidators(&opts)
 		if err != nil {
-			log.Error("BFT: invalid smart contract in genesis alloc", "err", err)
+			log.Error("QBFT: invalid smart contract in genesis alloc", "err", err)
 			return nil, err
 		}
 	} else {

--- a/consensus/istanbul/qbft/engine/engine_test.go
+++ b/consensus/istanbul/qbft/engine/engine_test.go
@@ -170,7 +170,7 @@ func TestWriteValidatorVote(t *testing.T) {
 
 func TestAccumulateRewards(t *testing.T) {
 	addr := common.HexToAddress("0xed9d02e382b34818e88b88a309c7fe71e65f419d")
-	besuMode := "besu"
+	fixedMode := "fixed"
 	listMode := "list"
 	validatorsMode := "validators"
 	emptyMode := ""
@@ -207,7 +207,7 @@ func TestAccumulateRewards(t *testing.T) {
 			miningBeneficiary: nil,
 			balance:           big.NewInt(1),
 			blockReward:       math.NewHexOrDecimal256(1),
-			mode:              &besuMode,
+			mode:              &fixedMode,
 			list:              nil,
 			expectedBalance:   big.NewInt(1),
 		},
@@ -216,7 +216,7 @@ func TestAccumulateRewards(t *testing.T) {
 			miningBeneficiary: &addr,
 			balance:           big.NewInt(1),
 			blockReward:       math.NewHexOrDecimal256(1),
-			mode:              &besuMode,
+			mode:              &fixedMode,
 			list:              nil,
 			expectedBalance:   big.NewInt(2),
 		},

--- a/params/config.go
+++ b/params/config.go
@@ -729,6 +729,9 @@ func (c *ChainConfig) CheckTransitionsData() error {
 		if transition.TransactionSizeLimit != 0 && transition.TransactionSizeLimit < 32 || transition.TransactionSizeLimit > 128 {
 			return ErrTransactionSizeLimit
 		}
+		if transition.BeneficiaryMode != nil && *transition.BeneficiaryMode != "besu" && *transition.BeneficiaryMode != "validators" && *transition.BeneficiaryMode != "" && *transition.BeneficiaryMode != "list" {
+			return ErrBeneficiaryMode
+		}
 		prevBlock = transition.Block
 	}
 	return nil

--- a/params/config.go
+++ b/params/config.go
@@ -428,6 +428,8 @@ func (c IBFTConfig) String() string {
 
 type QBFTConfig struct {
 	*BFTConfig
+	BlockReward       *big.Int       `json:"blockReward"`       // Reward from start, works only on QBFT consensus protocol
+	MiningBeneficiary common.Address `json:"miningBeneficiary"` // Wallet address of the mining beneficiary
 }
 
 func (c QBFTConfig) String() string {
@@ -435,8 +437,8 @@ func (c QBFTConfig) String() string {
 }
 
 const (
-	IBFT string = "ibft"
-	QBFT        = "qbft"
+	IBFT = "ibft"
+	QBFT = "qbft"
 
 	ContractMode    = "contract"
 	BlockHeaderMode = "blockheader"
@@ -459,6 +461,8 @@ type Transition struct {
 	MinerGasLimit                uint64         `json:"miner.gaslimit,omitempty"`               // Gas Limit
 	TwoFPlusOneEnabled           *bool          `json:"2FPlus1Enabled,omitempty"`               // Ceil(2N/3) is the default you need to explicitly use 2F + 1
 	TransactionSizeLimit         uint64         `json:"transactionSizeLimit,omitempty"`         // Modify TransactionSizeLimit
+	BlockReward                  *big.Int       `json:"blockReward,omitempty"`                  // validation rewards
+	MiningBeneficiary            common.Address `json:"miningBeneficiary"`                      // wallet address for validation rewards
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/config.go
+++ b/params/config.go
@@ -428,8 +428,8 @@ func (c IBFTConfig) String() string {
 
 type QBFTConfig struct {
 	*BFTConfig
-	BlockReward       *big.Int       `json:"blockReward"`       // Reward from start, works only on QBFT consensus protocol
-	MiningBeneficiary common.Address `json:"miningBeneficiary"` // Wallet address of the mining beneficiary
+	BlockReward       *big.Int        `json:"blockReward"`       // Reward from start, works only on QBFT consensus protocol
+	MiningBeneficiary *common.Address `json:"miningBeneficiary"` // Wallet address of the mining beneficiary
 }
 
 func (c QBFTConfig) String() string {
@@ -445,24 +445,24 @@ const (
 )
 
 type Transition struct {
-	Block                        *big.Int       `json:"block"`
-	Algorithm                    string         `json:"algorithm,omitempty"`
-	EpochLength                  uint64         `json:"epochlength,omitempty"`                  // Number of blocks that should pass before pending validator votes are reset
-	BlockPeriodSeconds           uint64         `json:"blockperiodseconds,omitempty"`           // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
-	EmptyBlockPeriodSeconds      uint64         `json:"emptyblockperiodseconds,omitempty"`      // Minimum time between two consecutive IBFT or QBFT a block and empty block’ timestamps in seconds
-	RequestTimeoutSeconds        uint64         `json:"requesttimeoutseconds,omitempty"`        // Minimum request timeout for each IBFT or QBFT round in milliseconds
-	ContractSizeLimit            uint64         `json:"contractsizelimit,omitempty"`            // Maximum smart contract code size
-	ValidatorContractAddress     common.Address `json:"validatorcontractaddress"`               // Smart contract address for list of validators
-	ValidatorSelectionMode       string         `json:"validatorselectionmode,omitempty"`       // Validator selection mode to switch to
-	EnhancedPermissioningEnabled *bool          `json:"enhancedPermissioningEnabled,omitempty"` // aka QIP714Block
-	PrivacyEnhancementsEnabled   *bool          `json:"privacyEnhancementsEnabled,omitempty"`   // privacy enhancements (mandatory party, private state validation)
-	PrivacyPrecompileEnabled     *bool          `json:"privacyPrecompileEnabled,omitempty"`     // enable marker transactions support
-	GasPriceEnabled              *bool          `json:"gasPriceEnabled,omitempty"`              // enable gas price
-	MinerGasLimit                uint64         `json:"miner.gaslimit,omitempty"`               // Gas Limit
-	TwoFPlusOneEnabled           *bool          `json:"2FPlus1Enabled,omitempty"`               // Ceil(2N/3) is the default you need to explicitly use 2F + 1
-	TransactionSizeLimit         uint64         `json:"transactionSizeLimit,omitempty"`         // Modify TransactionSizeLimit
-	BlockReward                  *big.Int       `json:"blockReward,omitempty"`                  // validation rewards
-	MiningBeneficiary            common.Address `json:"miningBeneficiary"`                      // wallet address for validation rewards
+	Block                        *big.Int        `json:"block"`
+	Algorithm                    string          `json:"algorithm,omitempty"`
+	EpochLength                  uint64          `json:"epochlength,omitempty"`                  // Number of blocks that should pass before pending validator votes are reset
+	BlockPeriodSeconds           uint64          `json:"blockperiodseconds,omitempty"`           // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
+	EmptyBlockPeriodSeconds      uint64          `json:"emptyblockperiodseconds,omitempty"`      // Minimum time between two consecutive IBFT or QBFT a block and empty block’ timestamps in seconds
+	RequestTimeoutSeconds        uint64          `json:"requesttimeoutseconds,omitempty"`        // Minimum request timeout for each IBFT or QBFT round in milliseconds
+	ContractSizeLimit            uint64          `json:"contractsizelimit,omitempty"`            // Maximum smart contract code size
+	ValidatorContractAddress     common.Address  `json:"validatorcontractaddress"`               // Smart contract address for list of validators
+	ValidatorSelectionMode       string          `json:"validatorselectionmode,omitempty"`       // Validator selection mode to switch to
+	EnhancedPermissioningEnabled *bool           `json:"enhancedPermissioningEnabled,omitempty"` // aka QIP714Block
+	PrivacyEnhancementsEnabled   *bool           `json:"privacyEnhancementsEnabled,omitempty"`   // privacy enhancements (mandatory party, private state validation)
+	PrivacyPrecompileEnabled     *bool           `json:"privacyPrecompileEnabled,omitempty"`     // enable marker transactions support
+	GasPriceEnabled              *bool           `json:"gasPriceEnabled,omitempty"`              // enable gas price
+	MinerGasLimit                uint64          `json:"miner.gaslimit,omitempty"`               // Gas Limit
+	TwoFPlusOneEnabled           *bool           `json:"2FPlus1Enabled,omitempty"`               // Ceil(2N/3) is the default you need to explicitly use 2F + 1
+	TransactionSizeLimit         uint64          `json:"transactionSizeLimit,omitempty"`         // Modify TransactionSizeLimit
+	BlockReward                  *big.Int        `json:"blockReward,omitempty"`                  // validation rewards
+	MiningBeneficiary            *common.Address `json:"miningBeneficiary"`                      // wallet address for validation rewards
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/config.go
+++ b/params/config.go
@@ -465,7 +465,7 @@ type Transition struct {
 	MinerGasLimit                uint64                `json:"miner.gaslimit,omitempty"`               // Gas Limit
 	TwoFPlusOneEnabled           *bool                 `json:"2FPlus1Enabled,omitempty"`               // Ceil(2N/3) is the default you need to explicitly use 2F + 1
 	TransactionSizeLimit         uint64                `json:"transactionSizeLimit,omitempty"`         // Modify TransactionSizeLimit
-  BlockReward                  *math.HexOrDecimal256 `json:"blockReward,omitempty"`                  // validation rewards
+	BlockReward                  *math.HexOrDecimal256 `json:"blockReward,omitempty"`                  // validation rewards
 	BeneficiaryMode              *string               `json:"beneficiaryMode,omitempty"`              // Mode for setting the beneficiary, either: list, besu, validators (beneficiary list is the list of validators)
 	BeneficiaryList              []common.Address      `json:"beneficiaryList,omitempty"`              // List of wallet addresses that have benefit at every new block (list mode)
 	MiningBeneficiary            *common.Address       `json:"miningBeneficiary,omitempty"`            // Wallet address that benefits at every new block (besu mode)

--- a/params/config.go
+++ b/params/config.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/crypto/sha3"
 )
@@ -428,8 +429,11 @@ func (c IBFTConfig) String() string {
 
 type QBFTConfig struct {
 	*BFTConfig
-	BlockReward       *big.Int        `json:"blockReward"`       // Reward from start, works only on QBFT consensus protocol
-	MiningBeneficiary *common.Address `json:"miningBeneficiary"` // Wallet address of the mining beneficiary
+	BlockReward       *math.HexOrDecimal256 `json:"blockReward,omitempty"`       // Reward from start, works only on QBFT consensus protocol
+	BeneficiaryMode   *string               `json:"beneficiaryMode,omitempty"`   // Mode for setting the beneficiary, either: list, besu, validators (beneficiary list is the list of validators)
+	BeneficiaryList   []common.Address      `json:"beneficiaryList,omitempty"`   // List of wallet addresses that have benefit at every new block (list mode)
+	MiningBeneficiary *common.Address       `json:"miningBeneficiary,omitempty"` // Wallet address that benefits at every new block (besu mode)
+
 }
 
 func (c QBFTConfig) String() string {
@@ -445,24 +449,27 @@ const (
 )
 
 type Transition struct {
-	Block                        *big.Int        `json:"block"`
-	Algorithm                    string          `json:"algorithm,omitempty"`
-	EpochLength                  uint64          `json:"epochlength,omitempty"`                  // Number of blocks that should pass before pending validator votes are reset
-	BlockPeriodSeconds           uint64          `json:"blockperiodseconds,omitempty"`           // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
-	EmptyBlockPeriodSeconds      uint64          `json:"emptyblockperiodseconds,omitempty"`      // Minimum time between two consecutive IBFT or QBFT a block and empty block’ timestamps in seconds
-	RequestTimeoutSeconds        uint64          `json:"requesttimeoutseconds,omitempty"`        // Minimum request timeout for each IBFT or QBFT round in milliseconds
-	ContractSizeLimit            uint64          `json:"contractsizelimit,omitempty"`            // Maximum smart contract code size
-	ValidatorContractAddress     common.Address  `json:"validatorcontractaddress"`               // Smart contract address for list of validators
-	ValidatorSelectionMode       string          `json:"validatorselectionmode,omitempty"`       // Validator selection mode to switch to
-	EnhancedPermissioningEnabled *bool           `json:"enhancedPermissioningEnabled,omitempty"` // aka QIP714Block
-	PrivacyEnhancementsEnabled   *bool           `json:"privacyEnhancementsEnabled,omitempty"`   // privacy enhancements (mandatory party, private state validation)
-	PrivacyPrecompileEnabled     *bool           `json:"privacyPrecompileEnabled,omitempty"`     // enable marker transactions support
-	GasPriceEnabled              *bool           `json:"gasPriceEnabled,omitempty"`              // enable gas price
-	MinerGasLimit                uint64          `json:"miner.gaslimit,omitempty"`               // Gas Limit
-	TwoFPlusOneEnabled           *bool           `json:"2FPlus1Enabled,omitempty"`               // Ceil(2N/3) is the default you need to explicitly use 2F + 1
-	TransactionSizeLimit         uint64          `json:"transactionSizeLimit,omitempty"`         // Modify TransactionSizeLimit
-	BlockReward                  *big.Int        `json:"blockReward,omitempty"`                  // validation rewards
-	MiningBeneficiary            *common.Address `json:"miningBeneficiary"`                      // wallet address for validation rewards
+	Block                        *big.Int              `json:"block"`
+	Algorithm                    string                `json:"algorithm,omitempty"`
+	EpochLength                  uint64                `json:"epochlength,omitempty"`                  // Number of blocks that should pass before pending validator votes are reset
+	BlockPeriodSeconds           uint64                `json:"blockperiodseconds,omitempty"`           // Minimum time between two consecutive IBFT or QBFT blocks’ timestamps in seconds
+	EmptyBlockPeriodSeconds      uint64                `json:"emptyblockperiodseconds,omitempty"`      // Minimum time between two consecutive IBFT or QBFT a block and empty block’ timestamps in seconds
+	RequestTimeoutSeconds        uint64                `json:"requesttimeoutseconds,omitempty"`        // Minimum request timeout for each IBFT or QBFT round in milliseconds
+	ContractSizeLimit            uint64                `json:"contractsizelimit,omitempty"`            // Maximum smart contract code size
+	ValidatorContractAddress     common.Address        `json:"validatorcontractaddress"`               // Smart contract address for list of validators
+	ValidatorSelectionMode       string                `json:"validatorselectionmode,omitempty"`       // Validator selection mode to switch to
+	EnhancedPermissioningEnabled *bool                 `json:"enhancedPermissioningEnabled,omitempty"` // aka QIP714Block
+	PrivacyEnhancementsEnabled   *bool                 `json:"privacyEnhancementsEnabled,omitempty"`   // privacy enhancements (mandatory party, private state validation)
+	PrivacyPrecompileEnabled     *bool                 `json:"privacyPrecompileEnabled,omitempty"`     // enable marker transactions support
+	GasPriceEnabled              *bool                 `json:"gasPriceEnabled,omitempty"`              // enable gas price
+	MinerGasLimit                uint64                `json:"miner.gaslimit,omitempty"`               // Gas Limit
+	TwoFPlusOneEnabled           *bool                 `json:"2FPlus1Enabled,omitempty"`               // Ceil(2N/3) is the default you need to explicitly use 2F + 1
+	TransactionSizeLimit         uint64                `json:"transactionSizeLimit,omitempty"`         // Modify TransactionSizeLimit
+	BlockReward                  *math.HexOrDecimal256 `json:"blockReward,omitempty"`                  // validation rewards
+	BeneficiaryMode              *string               `json:"beneficiaryMode,omitempty"`              // Mode for setting the beneficiary, either: list, besu, validators (beneficiary list is the list of validators)
+	BeneficiaryList              []common.Address      `json:"beneficiaryList,omitempty"`              // List of wallet addresses that have benefit at every new block (list mode)
+	MiningBeneficiary            *common.Address       `json:"miningBeneficiary,omitempty"`            // Wallet address that benefits at every new block (besu mode)
+
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/config.go
+++ b/params/config.go
@@ -729,7 +729,7 @@ func (c *ChainConfig) CheckTransitionsData() error {
 		if transition.TransactionSizeLimit != 0 && transition.TransactionSizeLimit < 32 || transition.TransactionSizeLimit > 128 {
 			return ErrTransactionSizeLimit
 		}
-		if transition.BeneficiaryMode != nil && *transition.BeneficiaryMode != "besu" && *transition.BeneficiaryMode != "validators" && *transition.BeneficiaryMode != "" && *transition.BeneficiaryMode != "list" {
+		if transition.BeneficiaryMode != nil && *transition.BeneficiaryMode != "fixed" && *transition.BeneficiaryMode != "validators" && *transition.BeneficiaryMode != "" && *transition.BeneficiaryMode != "list" {
 			return ErrBeneficiaryMode
 		}
 		prevBlock = transition.Block

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -331,10 +331,10 @@ func TestCheckTransitionsData(t *testing.T) {
 	}
 	var ibftTransitionsConfig, qbftTransitionsConfig, invalidTransition, invalidBlockOrder []Transition
 
-	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0}
-	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0}
-	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0}
-	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0}
+	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
+	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
+	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
+	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
 
 	ibftTransitionsConfig = append(ibftTransitionsConfig, tranI0, tranI10)
 	qbftTransitionsConfig = append(qbftTransitionsConfig, tranQ5, tranQ8)
@@ -394,7 +394,7 @@ func TestCheckTransitionsData(t *testing.T) {
 			wantErr: ErrBlockOrder,
 		},
 		{
-			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0}}},
+			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}}},
 			wantErr: ErrBlockNumberMissing,
 		},
 		{

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -331,10 +331,10 @@ func TestCheckTransitionsData(t *testing.T) {
 	}
 	var ibftTransitionsConfig, qbftTransitionsConfig, invalidTransition, invalidBlockOrder []Transition
 
-	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
-	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
-	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
-	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
+	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil}
+	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil}
+	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil}
+	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil}
 
 	ibftTransitionsConfig = append(ibftTransitionsConfig, tranI0, tranI10)
 	qbftTransitionsConfig = append(qbftTransitionsConfig, tranQ5, tranQ8)
@@ -394,7 +394,7 @@ func TestCheckTransitionsData(t *testing.T) {
 			wantErr: ErrBlockOrder,
 		},
 		{
-			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}}},
+			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil, nil, nil}}},
 			wantErr: ErrBlockNumberMissing,
 		},
 		{

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -331,10 +331,10 @@ func TestCheckTransitionsData(t *testing.T) {
 	}
 	var ibftTransitionsConfig, qbftTransitionsConfig, invalidTransition, invalidBlockOrder []Transition
 
-	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
-	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
-	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
-	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}
+	tranI0 := Transition{big.NewInt(0), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
+	tranQ5 := Transition{big.NewInt(5), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
+	tranI10 := Transition{big.NewInt(10), IBFT, 30000, 5, 5, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
+	tranQ8 := Transition{big.NewInt(8), QBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}
 
 	ibftTransitionsConfig = append(ibftTransitionsConfig, tranI0, tranI10)
 	qbftTransitionsConfig = append(qbftTransitionsConfig, tranQ5, tranQ8)
@@ -394,7 +394,7 @@ func TestCheckTransitionsData(t *testing.T) {
 			wantErr: ErrBlockOrder,
 		},
 		{
-			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, common.Address{}}}},
+			stored:  &ChainConfig{Transitions: []Transition{{nil, IBFT, 30000, 5, 10, 10, 50, common.Address{}, "", nil, nil, nil, nil, 0, nil, 0, nil, nil}}},
 			wantErr: ErrBlockNumberMissing,
 		},
 		{

--- a/params/errors.go
+++ b/params/errors.go
@@ -16,6 +16,7 @@ var (
 	ErrValidatorSelectionMode          = errors.New("validator selection mode is invalid, should be either `contract` or `blockheader`")
 	ErrMissingValidatorSelectionMode   = errors.New("validator selection mode is missing, should specify `contract` when using validatorcontractaddress")
 	ErrTransactionSizeLimit            = errors.New("genesis transaction size limit must be between 32 and 128")
+	ErrBeneficiaryMode                 = errors.New("beneficiary mode is not valid")
 )
 
 func ErrTransitionIncompatible(field string) error {


### PR DESCRIPTION
Configure a way to get rewards when there is a block validation.
There are 3 modes at the moment:
- list: you can provide a list a wallet addresses that will be rewarded of the amount of block reward at every validated block
- besu: compatible with the way besu works
- validators: all validators will be rewarded of the amount of block reward at every validated block, you don't have to provide the addresses, the list is computed

## list

as argument of qbft or program and transition

```
{
    "config": {
      "qbft": {
          "epoch": 30000,
          "policy": 0,
          "ceil2Nby3Block": 0,
          "beneficiaryMode":"list",
          "beneficiaryList":[
                    "0xed9d02e382b34818e88b88a309c7fe71e65f419d",
                    "0xca843569e3427144cead5e4d5999a3d0ccf92b8e"
          ]
      },
      "transitions": [
        {
          "block":12,
          "beneficiaryMode":"list",
          "beneficiaryList":["0xed9d02e382b34818e88b88a309c7fe71e65f419d"]
        }
      ]
    }
}
```