### PR TITLE
check nil pointer

### DIFF
--- a/consensus/istanbul/qbft/core/core.go
+++ b/consensus/istanbul/qbft/core/core.go
@@ -189,7 +189,7 @@ func (c *core) startNewRound(round *big.Int) {
 	c.valSet.CalcProposer(lastProposer, newView.Round.Uint64())
 	c.setState(StateAcceptRequest)
 
-	if round.Cmp(c.current.Round()) > 0 {
+	if c.current != nil && round.Cmp(c.current.Round()) > 0 {
 		roundMeter.Mark(new(big.Int).Sub(round, c.current.Round()).Int64())
 	}
 

--- a/consensus/istanbul/qbft/core/handler.go
+++ b/consensus/istanbul/qbft/core/handler.go
@@ -286,9 +286,12 @@ func (c *core) verifySignatures(m qbfttypes.QBFTMessage) error {
 }
 
 func (c *core) currentLogger(state bool, msg qbfttypes.QBFTMessage) log.Logger {
-	logCtx := []interface{}{
-		"current.round", c.current.Round().Uint64(),
-		"current.sequence", c.current.Sequence().Uint64(),
+	logCtx := []interface{}{}
+	if c.current != nil {
+		logCtx = append(logCtx,
+			"current.round", c.current.Round().Uint64(),
+			"current.sequence", c.current.Sequence().Uint64(),
+		)
 	}
 
 	if state {

--- a/consensus/istanbul/qbft/core/roundchange.go
+++ b/consensus/istanbul/qbft/core/roundchange.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"errors"
 	"math/big"
 	"sort"
 	"sync"
@@ -26,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	qbfttypes "github.com/ethereum/go-ethereum/consensus/istanbul/qbft/types"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -150,7 +152,12 @@ func (c *core) handleRoundChange(roundChange *qbfttypes.RoundChange) error {
 		// propose the block proposal that we generated
 		_, proposal := c.highestPrepared(currentRound)
 		if proposal == nil {
-			proposal = c.current.pendingRequest.Proposal
+			if c.current != nil && c.current.pendingRequest != nil {
+				proposal = c.current.pendingRequest.Proposal
+			} else {
+				log.Warn("round change returns an error: no proposal as pending request is nil")
+				return errors.New("no proposal as pending request is nil")
+			}
 		}
 
 		// Prepare justification for ROUND-CHANGE messages


### PR DESCRIPTION
fixes #1491 

Symptoms:
When a round change occurs, it is possible that the pending request is nil and that crashes the node.

Solution:
The best way found is to return an error for this case.

More:
Two other nil pointer checks that are not related to the issue.