### PR TITLE
Enable account plugins by default on clef

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -694,7 +694,7 @@ func signer(c *cli.Context) error {
 		cors := utils.SplitAndTrim(c.GlobalString(utils.HTTPCORSDomainFlag.Name))
 
 		srv := rpc.NewServer()
-		err := node.RegisterApisFromWhitelist(rpcAPI, []string{"account"}, srv, false)
+		err := node.RegisterApisFromWhitelist(rpcAPI, []string{"account", "plugin@account"}, srv, true)
 		if err != nil {
 			utils.Fatalf("Could not register API: %w", err)
 		}


### PR DESCRIPTION
Account plugins should be whitelisted and enabled when using clef