### PR TITLE
fix: incorrect link of QuickStart

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Key enhancements over go-ethereum:
 The above diagram is very high-level overview of component architecture used by GoQuorum. For more in-depth discussion of the components and how they interact, please refer to [lifecycle of a private transaction](https://consensys.net/docs/goquorum/en/latest/concepts/privacy/private-transaction-lifecycle/).
 
 ## Quickstart
-The easiest way to get started is to use * [quorum-dev-quickstart](https://consensys.net/docs/goquorum/en/latest/tutorials/quorum-dev-quickstart/getting-started/) - a command line tool that allows users to set up a development GoQuorum network on their local machine in less than *2 minutes*.
+The easiest way to get started is to use * [quorum-dev-quickstart](https://consensys.net/docs/goquorum/en/latest/tutorials/quorum-dev-quickstart/using-the-quickstart/) - a command line tool that allows users to set up a development GoQuorum network on their local machine in less than *2 minutes*.
 
 ## GoQuorum Projects
 


### PR DESCRIPTION
The page where link refer is not existing.