### PR TITLE
perf: improved func ValidateNodeForTxn node id parsing

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -344,7 +344,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	if !pcore.ValidateNodeForTxn(b.nodeId, signedTx.From()) {
 		return errors.New("cannot send transaction from this node")
 	}
-	// End Quourum
+	// End Quorum
 	return b.eth.txPool.AddLocal(signedTx)
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/miner"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
 	pcore "github.com/ethereum/go-ethereum/permission/core"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -55,8 +56,8 @@ type EthAPIBackend struct {
 
 	// Quorum
 	//
-	// hex node id from node public key
-	hexNodeId string
+	// node id from node public key
+	nodeId enode.ID
 
 	// timeout value for call
 	evmCallTimeOut time.Duration
@@ -337,11 +338,13 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	// Quourum
 	// validation for node need to happen here and cannot be done as a part of
 	// validateTx in tx_pool.go as tx_pool validation will happen in every node
-	if b.hexNodeId != "" && !pcore.ValidateNodeForTxn(b.hexNodeId, signedTx.From()) {
+	if !pcore.ValidateNodeForTxn(b.nodeId, signedTx.From()) {
 		return errors.New("cannot send transaction from this node")
 	}
+	// End Quourum
 	return b.eth.txPool.AddLocal(signedTx)
 }
 

--- a/permission/core/cache.go
+++ b/permission/core/cache.go
@@ -132,7 +132,6 @@ type OrgDetailInfo struct {
 }
 
 var syncStarted = false
-var emptyNodeId = enode.ID{}
 var defaultAccess = FullAccess
 var qip714BlockReached = false
 var networkBootUpCompleted = false
@@ -601,7 +600,7 @@ func CheckIfAdminAccount(acctId common.Address) bool {
 
 // validates if the account can transact from the current node
 func ValidateNodeForTxn(nodeId enode.ID, from common.Address) bool {
-	if !PermissionsEnabled() || nodeId == emptyNodeId {
+	if !PermissionsEnabled() || nodeId == (enode.ID{}) {
 		return true
 	}
 


### PR DESCRIPTION
Enhanced permission ValidateNodeForTxn function contains repeating parsing of enode identifier from NodeInfo.Url field. This fix stores parsed enode id value to cached NodeInfo object and reuse stored value on each ValidateNodeForTxn function call.

In our EOA transactions performance test with enabled enhanced permission, this fix decrease CPU usage on ~10% in collected pprof report.

Benchmark source:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/permission/core
cpu: Intel(R) Xeon(R) CPU E5-2696 v3 @ 2.30GHz
BenchmarkValidateNodeForTxn-8             100000             17177 ns/op           11911 B/op        181 allocs/op
BenchmarkValidateNodeForTxn-8             100000             16033 ns/op           11914 B/op        181 allocs/op
BenchmarkValidateNodeForTxn-8             100000             16371 ns/op           11886 B/op        181 allocs/op
BenchmarkValidateNodeForTxn-8             100000             16227 ns/op           11915 B/op        181 allocs/op
BenchmarkValidateNodeForTxn-8             100000             15923 ns/op           11870 B/op        181 allocs/op
PASS
ok      github.com/ethereum/go-ethereum/permission/core 8.204s
```

Benchmark fix:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/permission/core
cpu: Intel(R) Xeon(R) CPU E5-2696 v3 @ 2.30GHz
BenchmarkValidateNodeForTxn-8             100000              1104 ns/op              40 B/op          3 allocs/op
BenchmarkValidateNodeForTxn-8             100000              1750 ns/op              40 B/op          3 allocs/op
BenchmarkValidateNodeForTxn-8             100000              1584 ns/op              41 B/op          3 allocs/op
BenchmarkValidateNodeForTxn-8             100000              1467 ns/op              41 B/op          3 allocs/op
BenchmarkValidateNodeForTxn-8             100000              1631 ns/op              42 B/op          3 allocs/op
PASS
ok      github.com/ethereum/go-ethereum/permission/core 0.789s
```
