### PR TITLE
extension: expose generation of management contract uuid to allow external signing of approval request

### DIFF
--- a/extension/proxy_api.go
+++ b/extension/proxy_api.go
@@ -45,10 +45,10 @@ func (api *PrivateExtensionProxyAPI) ActiveExtensionContracts(ctx context.Contex
 	return extracted
 }
 
-func (api *PrivateExtensionProxyAPI) GenerateExtensionApprovalUuid(ctx context.Context, addressToVoteOn common.Address, txa ethapi.SendTxArgs) (string, error) {
+func (api *PrivateExtensionProxyAPI) GenerateExtensionApprovalUuid(ctx context.Context, addressToVoteOn common.Address, externalSignerAddress common.Address, txa ethapi.SendTxArgs) (string, error) {
 	log.Info("QLight - proxy enabled")
 	var result string
-	err := api.proxyClient.CallContext(ctx, &result, "quorumExtension_generateExtensionApprovalUuid", addressToVoteOn, txa)
+	err := api.proxyClient.CallContext(ctx, &result, "quorumExtension_generateExtensionApprovalUuid", addressToVoteOn, externalSignerAddress, txa)
 	return result, err
 }
 

--- a/extension/proxy_api.go
+++ b/extension/proxy_api.go
@@ -45,6 +45,13 @@ func (api *PrivateExtensionProxyAPI) ActiveExtensionContracts(ctx context.Contex
 	return extracted
 }
 
+func (api *PrivateExtensionProxyAPI) GenerateExtensionApprovalUuid(ctx context.Context, addressToVoteOn common.Address, txa ethapi.SendTxArgs) (string, error) {
+	log.Info("QLight - proxy enabled")
+	var result string
+	err := api.proxyClient.CallContext(ctx, &result, "quorumExtension_generateExtensionApprovalUuid", addressToVoteOn, txa)
+	return result, err
+}
+
 // ApproveContractExtension submits the vote to the specified extension management contract. The vote indicates whether to extend
 // a given contract to a new participant or not
 func (api *PrivateExtensionProxyAPI) ApproveExtension(ctx context.Context, addressToVoteOn common.Address, vote bool, txa ethapi.SendTxArgs) (string, error) {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -1255,7 +1255,7 @@ web3._extend({
 			name: 'generateExtensionApprovalUuid',
 			call: 'quorumExtension_generateExtensionApprovalUuid',
 			params: 2,
-			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputTransactionFormatter]
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputTransactionFormatter]
 		}),
 		new web3._extend.Method({
 			name: 'approveExtension',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -1252,6 +1252,12 @@ web3._extend({
 	methods:
 	[
 		new web3._extend.Method({
+			name: 'generateExtensionApprovalUuid',
+			call: 'quorumExtension_generateExtensionApprovalUuid',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputAddressFormatter, web3._extend.formatters.inputTransactionFormatter]
+		}),
+		new web3._extend.Method({
 			name: 'approveExtension',
 			call: 'quorumExtension_approveExtension',
 			params: 3,


### PR DESCRIPTION
This PR introduces the following changes to the extension API:

1. Expose the generation of management contract uuid as a json-rpc call

This allows the subsequent transaction for approval of contract state extension to be submitted as a rawPrivateTransaction and signed externally to the `doVote` function of the management contract. 