### PR TITLE
Allow migration of maxCodeSizeConfig to transitions.contractsizelimit

### DIFF
--- a/permission/permission_test.go
+++ b/permission/permission_test.go
@@ -125,6 +125,8 @@ func setup() {
 			Balance: big.NewInt(100000000000000),
 		},
 	}
+	conf := params.AllEthashProtocolChanges
+	conf.Transitions = []params.Transition{{Block: big.NewInt(0), ContractSizeLimit: 32 * 1024}}
 	ethConf := &eth.Config{
 		Genesis: &core.Genesis{Config: params.AllEthashProtocolChanges, GasLimit: 10000000000, Alloc: genesisAlloc},
 		Miner:   miner.Config{Etherbase: guardianAddress},


### PR DESCRIPTION
* Require genesis to specify max contract size using Transitions config.
* Add checks to allow migrating from a prior maxCodeSizeConfig to contractsizelimit specified in Transitions config.
* **NOTE**: Remove support for legacy max code size genesis configuration by rejecting genesis config that specifies only maxCodeSizeConfig or maxCodeSize and maxCodeSizeChangeBlock.
* cosmetic enhancement to a log message on startup to include Transitions since this is useful information for node operators.

FYI, given that the notice to use `Transitions` in lieu of the legacy max code size config parameters has been advertised for more than a year, I felt that it is not premature to remove support for it.

Fixes: https://github.com/ConsenSys/quorum/issues/1622