### PR TITLE
Fix abigen not supporting enhanced privacy for go

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -546,7 +546,17 @@ func (ec *Client) SendTransaction(ctx context.Context, tx *types.Transaction, ar
 		return err
 	}
 	if args.PrivateFor != nil {
-		return ec.c.CallContext(ctx, nil, "eth_sendRawPrivateTransaction", hexutil.Encode(data), bind.PrivateTxArgs{PrivateFor: args.PrivateFor})
+		privateTxArgs := bind.PrivateTxArgs{PrivateFor: args.PrivateFor}
+		if args.PrivacyFlag.IsNotStandardPrivate() {
+			privateTxArgs.PrivacyFlag = args.PrivacyFlag
+		}
+		if args.MandatoryRecipients != nil {
+			privateTxArgs.MandatoryRecipients = args.MandatoryRecipients
+		}
+		if args.PrivateFrom != "" {
+			privateTxArgs.PrivateFrom = args.PrivateFrom
+		}
+		return ec.c.CallContext(ctx, nil, "eth_sendRawPrivateTransaction", hexutil.Encode(data), privateTxArgs)
 	} else {
 		return ec.c.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data))
 	}


### PR DESCRIPTION
abigen creates wrapper contract structs that do not have the capability to specify enhanced privacy options. This PR allows users to pass in privacy flag, private from and mandatory for fields to a generated wrapper.