### PR TITLE
Add function to toggle on/off IP Validation in Enhanced Permissioing NodeManager.

### DIFF
--- a/permission/v2/contract/NodeManager.sol
+++ b/permission/v2/contract/NodeManager.sol
@@ -38,7 +38,8 @@ contract NodeManager {
     mapping(bytes32 => uint256) private enodeIdToIndex;
     // tracking total number of nodes in network
     uint256 private numberOfNodes;
-
+    // whether to do IP validation during checks if connection is allowed. This is enabled by default.
+    bool private isIpValidationEnabled = true;
 
     // node permission events for new node propose
     event NodeProposed(string _enodeId, string _ip, uint16 _port, uint16 _raftport, string _orgId);
@@ -289,6 +290,15 @@ contract NodeManager {
         return nodeList[_getNodeIndex(_enodeId)].status;
     }
 
+    /** @notice specify whether to perform source node IP validation in determining the connection permission.
+        This is enabled by default.
+      * @param _isIpValidationEnabled whether to enable or disable the IP validation
+      */
+    function setIpValidation(bool _isIpValidationEnabled) public 
+    onlyImplementation {
+        isIpValidationEnabled = _isIpValidationEnabled;
+    }
+
     /** @notice checks if the node is allowed to connect or not
     * @param _enodeId enode id
     * @param _ip IP of node
@@ -301,7 +311,11 @@ contract NodeManager {
             return false;
         }
         uint256 nodeIndex = _getNodeIndex(_enodeId);
-        if (nodeList[nodeIndex].status == 2 && keccak256(abi.encode(nodeList[nodeIndex].ip)) == keccak256(abi.encode(_ip))) {
+        if (nodeList[nodeIndex].status == 2 
+            && (!isIpValidationEnabled 
+                || keccak256(abi.encode(nodeList[nodeIndex].ip)) == keccak256(abi.encode(_ip))
+            )
+        ) {
             return true;
         }
 

--- a/permission/v2/contract/PermissionsImplementation.sol
+++ b/permission/v2/contract/PermissionsImplementation.sol
@@ -165,6 +165,17 @@ contract PermissionsImplementation {
         roleManager.addRole(adminRole, adminOrg, fullAccess, true, true);
         accountManager.setDefaults(adminRole, orgAdminRole);
     }
+
+    /** @notice specify whether to perform source node IP validation in determining the connection permission.
+        This can only be set before network initialization is finalized
+      * @param _isIpValidationEnabled whether to enable or disable the IP validation
+      */
+    function setIpValidation(bool _isIpValidationEnabled) external 
+    onlyInterface
+    networkBootStatus(false) {
+        nodeManager.setIpValidation(_isIpValidationEnabled);
+    }
+
     /** @notice as a part of network initialization add all nodes which
         are part of static-nodes.json as nodes belonging to
         network admin org

--- a/permission/v2/contract/PermissionsInterface.sol
+++ b/permission/v2/contract/PermissionsInterface.sol
@@ -47,6 +47,13 @@ contract PermissionsInterface {
         permImplementation.init(_breadth, _depth);
     }
 
+    /** @notice specify whether to perform source node IP validation in determining the connection permission.
+      * @param _isIpValidationEnabled whether to enable or disable the IP validation
+      */
+    function setIpValidation(bool _isIpValidationEnabled) external {
+        permImplementation.setIpValidation(_isIpValidationEnabled);
+    }
+
     /** @notice interface to add new node to an admin organization
       * @param _enodeId enode id of the node to be added
       * @param _ip IP of node


### PR DESCRIPTION
**Use case** 
We are running a 1st Quorum node in kubernetes pod with Enhanced Permissioning v2 enabled. A 2nd quorum node is hosted in another kubernetes cluster / namespace also running Enhanced Permissioning v2. The 1st and 2nd quorum node's enodeIds, ports and IP addresses were added to the list of nodes that are allowed to connect. The **geth** API `quorumPermission_addNode()` was used.
However, the 1st and 2nd node are not able to connect to each other because, for example - the incoming connection from 2nd node's IP has changed. Based on discussion with our infra team, and due to securities in place, the IP address of incoming connection may change or re-written before the connection request finally reach the pod where the other Quorum node is running. Due to this, the  `connectionAllowed()` of `v2/contract/NodeManager.sol` rejects the connection.

**Proposed Solution / Changes**
I am proposing in this change to introduce a `setIpValidation()` function in NodeManager.sol to toggle IP validation on or off. This is enabled by default. The property can only be set before network boot status is finalized.

For your review / comments. Let me know if you require further information. I will be more than happy to provide them and to help contribute further. I look forward working with you.

Thank you in advance.

Regards, John