### PR TITLE
geth: add new update transitions helper utility

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -269,6 +269,7 @@ func init() {
 	app.Commands = []cli.Command{
 		// See chaincmd.go:
 		initCommand,
+		updateCommand,
 		mpsdbUpgradeCommand,
 		importCommand,
 		exportCommand,

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
 	google.golang.org/grpc v1.46.0
+	google.golang.org/protobuf v1.28.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 	gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce


### PR DESCRIPTION
Transitions for IBFT and QBFT are configurations stored under genesis block. Genesis block are written when `geth init` is called. There are many instances when new transitions are introduced which does not require an entire rewrite of the rest of the chain configuration, nor the genesis block.

This PR introduces an additional helper method, `geth update` to allow for the selective updates of only transitions to be written down to chain configuration. This reduces the number of configurations which might be unintentionally updated when calling `geth init`, and also makes it clearer to the user on how to add transitions to an existing network.