### PR TITLE
fix: fix slice init length

### DIFF
--- a/consensus/istanbul/ibft/engine/engine_test.go
+++ b/consensus/istanbul/ibft/engine/engine_test.go
@@ -27,7 +27,7 @@ func TestPrepareExtra(t *testing.T) {
 	validators[2] = common.BytesToAddress(hexutil.MustDecode("0x6beaaed781d2d2ab6350f5c4566a2c6eaac407a6"))
 	validators[3] = common.BytesToAddress(hexutil.MustDecode("0x8be76812f765c24641ec63dc2852b378aba2b440"))
 
-	vanity := make([]byte, types.IstanbulExtraVanity)
+	vanity := make([]byte, 0, types.IstanbulExtraVanity)
 	expectedResult := append(vanity, hexutil.MustDecode("0xf858f8549444add0ec310f115a0e603b2d7db9f067778eaf8a94294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212946beaaed781d2d2ab6350f5c4566a2c6eaac407a6948be76812f765c24641ec63dc2852b378aba2b44080c0")...)
 
 	h := &types.Header{


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of types.IstanbulExtraVanity rather than initializing the length of this slice.