### PR TITLE
Additional logging when forking happens

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2159,6 +2159,15 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 				"diff", block.Difficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
 				"root", block.Root())
+			// Quorum
+			if bc.chainConfig.IsQuorum {
+				log.Error("Fork detected - which is not an expected behavior in Quorum",
+					"number", block.Number(), "hash", block.Hash(),
+					"diff", block.Difficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
+					"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
+					"root", block.Root())
+			}
+			// End Quorum
 
 		default:
 			// This in theory is impossible, but lets be nice to our future selves and leave


### PR DESCRIPTION
The extra error log introduces an alert for fork detection specific to Quorum, which can be useful for monitoring and quickly identifying unexpected consensus issues